### PR TITLE
UI: Persist training results to app data and surface server errors with improved UI error handling

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -153,7 +153,8 @@ function startPythonServer() {
       env: {
         ...process.env,
         'PYTORCH_ENABLE_MPS_FALLBACK': '1',
-        'ELECTRON_RUN': 'true'
+        'ELECTRON_RUN': 'true',
+        'TORCHWM_RESULTS_DIR': path.join(app.getPath('userData'), 'results')
       }
     });
 

--- a/torchwm_ui/src/App.tsx
+++ b/torchwm_ui/src/App.tsx
@@ -239,16 +239,22 @@ export default function App() {
 
   async function runAction(action: () => Promise<unknown>) {
     setIsSubmitting(true); setErrorMessage(null);
-    try { await action(); await refreshState(); }
-    catch (e) { setErrorMessage((e as Error).message); }
-    finally { setIsSubmitting(false); }
+    try {
+      await action();
+      await refreshState();
+    } catch (e) {
+      setErrorMessage((e as Error).message);
+      throw e;
+    } finally {
+      setIsSubmitting(false);
+    }
   }
 
 const handleLoadModel = () => {
     toast.loading("Loading model...", { id: "loadModel" });
     runAction(() => loadModel(selectedModel, {}))
       .then(() => toast.success(`Model "${selectedModel}" loaded successfully!`, { id: "loadModel" }))
-      .catch(() => {});
+      .catch((e) => toast.error((e as Error).message, { id: "loadModel" }));
   };
   const handleLoadEnv = () => {
     if (!selectedEnvironment) {
@@ -259,13 +265,13 @@ const handleLoadModel = () => {
     toast.loading("Loading environment...", { id: "loadEnv" });
     runAction(() => loadEnvironment(selectedEnvironment, selectedBackend, {}))
       .then(() => toast.success(`Environment "${selectedEnvironment}" loaded successfully!`, { id: "loadEnv" }))
-      .catch(() => {});
+      .catch((e) => toast.error((e as Error).message, { id: "loadEnv" }));
   };
   const handleStart = () => {
     toast.loading("Starting training...", { id: "startTraining" });
     runAction(() => startTraining(trainingConfig))
       .then(() => toast.success("Training started!", { id: "startTraining" }))
-      .catch(() => {});
+      .catch((e) => toast.error((e as Error).message, { id: "startTraining" }));
   };
   const handleStop = () => runAction(() => stopTraining());
 
@@ -377,6 +383,17 @@ return (
           </div>
 
           {errorMessage && <div className="error">{errorMessage}</div>}
+          {state?.status === "failed" && (
+            <div className="error">
+              {state.message}
+              {state.traceback && (
+                <details>
+                  <summary>Show traceback</summary>
+                  <pre>{state.traceback}</pre>
+                </details>
+              )}
+            </div>
+          )}
         </aside>
 
         <div className="content">

--- a/torchwm_ui/src/styles.css
+++ b/torchwm_ui/src/styles.css
@@ -363,6 +363,17 @@ body {
   font-size: 0.75rem;
 }
 
+.error details {
+  margin-top: 0.4rem;
+}
+
+.error pre {
+  margin-top: 0.4rem;
+  max-height: 10rem;
+  overflow: auto;
+  white-space: pre-wrap;
+}
+
 .content {
   flex: 1;
   display: flex;

--- a/world_models/ui/server.py
+++ b/world_models/ui/server.py
@@ -53,6 +53,14 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
+def _default_results_dir(run_name: str) -> Path:
+    """Resolve a writable results directory for UI-triggered training runs."""
+    configured_root = os.environ.get("TORCHWM_RESULTS_DIR", "").strip()
+    if configured_root:
+        return Path(configured_root).expanduser() / run_name
+    return Path("results") / run_name
+
+
 SUPPORTED_MODELS: dict[str, dict[str, str]] = {
     "dreamerv1": {
         "label": "DreamerV1",
@@ -646,6 +654,7 @@ class TrainingController:
                     self._status = "completed"
                     self._message = "Training completed."
         except Exception as exc:
+            logger.error("Training failed", exc_info=True)
             with self._lock:
                 self._status = "failed"
                 self._message = f"{type(exc).__name__}: {exc}"
@@ -664,9 +673,7 @@ class TrainingController:
             raise ValueError("Dreamer requires an environment.")
 
         results_dir = str(
-            train_cfg.get(
-                "results_dir", Path("results") / f"ui_dreamer_{int(time.time())}"
-            )
+            train_cfg.get("results_dir", _default_results_dir(f"ui_dreamer_{int(time.time())}"))
         )
         Path(results_dir).mkdir(parents=True, exist_ok=True)
         with self._lock:
@@ -776,9 +783,7 @@ class TrainingController:
             raise ValueError("Planet requires an environment.")
 
         results_dir = str(
-            train_cfg.get(
-                "results_dir", Path("results") / f"ui_planet_{int(time.time())}"
-            )
+            train_cfg.get("results_dir", _default_results_dir(f"ui_planet_{int(time.time())}"))
         )
         Path(results_dir).mkdir(parents=True, exist_ok=True)
         with self._lock:


### PR DESCRIPTION
### Motivation

- Ensure training runs started from the Electron UI write results to a writable per-user location instead of the repo root.
- Surface server-side failures and tracebacks to the UI so users can see error details when a training job fails.
- Improve UI error handling so actions report failures via toasts and the submitting state is managed correctly.

### Description

- Set a `TORCHWM_RESULTS_DIR` environment variable when spawning the Python server using `app.getPath('userData')/results` in `electron/main.js`.
- Add `_default_results_dir` to `world_models/ui/server.py` to resolve results directories from `TORCHWM_RESULTS_DIR` and use it for Dreamer and Planet runs, and add an error log in the training exception handler.
- Update `torchwm_ui/src/App.tsx` to rethrow errors from `runAction` after setting the error state, show error toasts with messages for `handleLoadModel`, `handleLoadEnv`, and `handleStart`, and render failed run message plus expandable traceback in the UI when `state.status === "failed"`.
- Add CSS rules in `torchwm_ui/src/styles.css` to style the error details and make tracebacks scrollable.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3e9f8e870832e897aec87101ba486)