### PR TITLE
refactor: clean public API, migrate to gymnasium, add operator factory

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,7 +11,11 @@ sys.path.insert(0, os.path.abspath("../.."))
 project = "TorchWM"
 copyright = f"{datetime.now().year}, Param Thakkar"
 author = "Param Thakkar"
-release = "0.2.1"
+
+# Auto-read version from world_models package
+import world_models
+
+release = world_models.__version__
 
 extensions = [
     "sphinx.ext.autodoc",

--- a/docs/source/package_overview.md
+++ b/docs/source/package_overview.md
@@ -2,47 +2,74 @@
 
 TorchWM is organized into focused modules so you can use only the pieces you need.
 
-## Core APIs
+## Quick Import (Public API)
 
-- `world_models.models`: High-level models and agents (`Dreamer`, `DreamerAgent`, `Planet`, `JEPAAgent`)
-- `world_models.configs`: Configuration containers for Dreamer, JEPA, and diffusion runs
+Import everything you need from a single namespace:
+
+```python
+import world_models
+# or
+from world_models import DreamerAgent, DreamerConfig
+```
+
+### Available Exports
+
+| Category | Exports |
+|----------|--------|
+| **Models** | `Dreamer`, `Planet`, `DreamerAgent`, `JEPAAgent`, `VisionTransformer`, `ModularRSSM`, `create_modular_rssm` |
+| **Configs** | `DreamerConfig`, `JEPAConfig`, `DiTConfig`, `DiamondConfig`, `IRISConfig` |
+| **Environments** | `make_atari_env`, `GymImageEnv`, `DeepMindControlEnv`, `UnityMLAgentsEnv`, `TimeLimit`, `ActionRepeat`, etc. |
+| **Operators** | `get_operator`, `DreamerOperator`, `JEPAOperator`, `IrisOperator`, `PlaNetOperator` |
+| **Reward** | `RewardModel`, `ValueModel` |
+| **Utilities** | `__version__` |
+
+Example usage:
+
+```python
+from world_models import DreamerAgent, DreamerConfig
+from world_models import get_operator
+
+# Training
+cfg = DreamerConfig()
+cfg.env = "walker-walk"
+agent = DreamerAgent(cfg)
+agent.train()
+
+# Inference preprocessing
+op = get_operator('dreamer', image_size=64, action_dim=6)
+processed = op.process({'image': image, 'action': action})
+```
+
+## Core Modules
+
+- `world_models.models`: High-level models and agents
+- `world_models.configs`: Configuration containers
 - `world_models.training`: Script-style training entrypoints
 
 ## Environment Integration
 
-- `world_models.envs`: Environment adapters for DMC, Gym/Gymnasium, Atari, MuJoCo, Unity ML-Agents
-- `world_models.envs.wrappers`: Common wrappers for action repeat, action normalization, time limits, and observation shaping
+- `world_models.envs`: DMC, Gym/Gymnasium, Atari, MuJoCo, Unity ML-Agents adapters
+- `world_models.envs.wrappers`: Action repeat, normalization, time limits
 
 ## World Model Building Blocks
 
-- `world_models.models.dreamer_rssm`: Recurrent state-space model used by Dreamer
-- `world_models.models.modular_rssm`: Modular RSSM with swappable encoder/decoder/backbone for research experiments
-- `world_models.vision`: Encoders/decoders and action heads for latent dynamics models
-- `world_models.reward`: Reward and value prediction heads
-- `world_models.observations`: Symbolic and visual observation reconstruction modules
+- `world_models.models.dreamer_rssm`: Recurrent state-space model
+- `world_models.models.modular_rssm`: Modular RSSM
+- `world_models.vision`: Encoders/decoders
+- `world_models.reward`: Reward and value heads
 
 ## Representation Learning and Diffusion
 
-- `world_models.models.vit`: Vision Transformer and JEPA predictor components
-- `world_models.models.diffusion`: DDPM scheduler and DiT model implementation
-- `world_models.masks`: Mask collators for JEPA-style context/target masking
+- `world_models.models.vit`: Vision Transformer and JEPA
+- `world_models.models.diffusion`: DDPM and DiT
+- `world_models.masks`: Mask collators
 
 ## Data and Memory
 
-- `world_models.datasets`: CIFAR-10, ImageNet-1K, and generic `ImageFolder` dataset loaders
-- `world_models.memory`: Replay buffers for Dreamer and episode-based memory for PlaNet/RSSM
+- `world_models.datasets`: CIFAR-10, ImageNet-1K loaders
+- `world_models.memory`: Replay buffers
 
 ## Utilities
 
-- `world_models.utils.dreamer_utils`: Logging, parameter freezing, and TD(lambda) return computation
-- `world_models.utils.jepa_utils`: Optimizer schedules, distributed helpers, and training meters
-- `world_models.transforms`: Data augmentation pipelines used by JEPA/vision training
-- `world_models.benchmarks`: Lightweight benchmarking harness and adapters for DIAMOND, IRIS, and Dreamer; includes a CLI and reporting utilities for CSV/Markdown/JSON exports
-
-## Which API Should I Use?
-
-- End-to-end Dreamer training: `DreamerAgent`
-- End-to-end JEPA training: `JEPAAgent`
-- Low-level model experimentation: `Dreamer`, `RSSM`, decoder/encoder modules
-- Custom world model architectures: `ModularRSSM` with swappable encoder/decoder/backbone
-- Custom data pipelines: `make_cifar10`, `make_imagenet1k`, `make_imagefolder`
+- `world_models.utils`: Logging, transforms, benchmarks
+- `world_models.benchmarks`: CLI and reporting

--- a/docs/source/package_overview.md
+++ b/docs/source/package_overview.md
@@ -71,5 +71,14 @@ processed = op.process({'image': image, 'action': action})
 
 ## Utilities
 
-- `world_models.utils`: Logging, transforms, benchmarks
-- `world_models.benchmarks`: CLI and reporting
+- `world_models.utils`: Logging, parameter freezing, transforms
+- `world_models.transforms`: Data augmentation pipelines
+- `world_models.benchmarks`: CLI and reporting utilities
+
+## Which API Should I Use?
+
+- End-to-end Dreamer training: `DreamerAgent`
+- End-to-end JEPA training: `JEPAAgent`
+- Low-level model experimentation: `Dreamer`, `RSSM`, decoder/encoder modules
+- Custom world model architectures: `ModularRSSM` with swappable encoder/decoder/backbone
+- Custom data pipelines: `make_cifar10`, `make_imagenet1k`, `make_imagefolder`

--- a/docs/source/package_overview.md
+++ b/docs/source/package_overview.md
@@ -42,8 +42,8 @@ processed = op.process({'image': image, 'action': action})
 
 ## Core Modules
 
-- `world_models.models`: High-level models and agents
-- `world_models.configs`: Configuration containers
+- `world_models.models`: High-level models and agents (`Dreamer`, `DreamerAgent`, `Planet`, `JEPAAgent`)
+- `world_models.configs`: Configuration containers for Dreamer, JEPA, and diffusion runs
 - `world_models.training`: Script-style training entrypoints
 
 ## Environment Integration
@@ -53,21 +53,22 @@ processed = op.process({'image': image, 'action': action})
 
 ## World Model Building Blocks
 
-- `world_models.models.dreamer_rssm`: Recurrent state-space model
-- `world_models.models.modular_rssm`: Modular RSSM
-- `world_models.vision`: Encoders/decoders
-- `world_models.reward`: Reward and value heads
+- `world_models.models.dreamer_rssm`: Recurrent state-space model used by Dreamer
+- `world_models.models.modular_rssm`: Modular RSSM with swappable encoder/decoder/backbone for research experiments
+- `world_models.vision`: Encoders/decoders and action heads for latent dynamics models
+- `world_models.reward`: Reward and value prediction heads
+- `world_models.observations`: Symbolic and visual observation reconstruction modules
 
 ## Representation Learning and Diffusion
 
-- `world_models.models.vit`: Vision Transformer and JEPA
-- `world_models.models.diffusion`: DDPM and DiT
-- `world_models.masks`: Mask collators
+- `world_models.models.vit`: Vision Transformer and JEPA predictor components
+- `world_models.models.diffusion`: DDPM scheduler and DiT model implementation
+- `world_models.masks`: Mask collators for JEPA-style context/target masking
 
 ## Data and Memory
 
-- `world_models.datasets`: CIFAR-10, ImageNet-1K loaders
-- `world_models.memory`: Replay buffers
+- `world_models.datasets`: CIFAR-10, ImageNet-1K, and generic `ImageFolder` dataset loaders
+- `world_models.memory`: Replay buffers for Dreamer and episode-based memory for PlaNet/RSSM
 
 ## Utilities
 

--- a/world_models/__init__.py
+++ b/world_models/__init__.py
@@ -1,0 +1,145 @@
+"""
+TorchWM - Modular PyTorch Library for World Models
+
+Public API exports for easy imports.
+
+Usage:
+    from world_models import DreamerAgent, DreamerConfig
+    agent = DreamerAgent(DreamerConfig())
+    agent.train()
+"""
+
+__version__ = "0.3.2"
+
+
+def __getattr__(name):
+    """Lazy import to avoid loading unused modules and their dependencies."""
+    # Models & Agents
+    if name in (
+        "Dreamer",
+        "Planet",
+        "DreamerAgent",
+        "JEPAAgent",
+        "VisionTransformer",
+        "ModularRSSM",
+        "create_modular_rssm",
+    ):
+        from world_models import models as _models
+
+        return getattr(_models, name)
+
+    # Configs
+    if name in (
+        "DreamerConfig",
+        "JEPAConfig",
+        "DiTConfig",
+        "get_dit_config",
+        "DiamondConfig",
+        "IRISConfig",
+        "ATARI_100K_GAMES",
+        "HUMAN_SCORES",
+        "RANDOM_SCORES",
+    ):
+        from world_models import configs as _configs
+
+        return getattr(_configs, name)
+
+    # Environments
+    if name in (
+        "make_atari_env",
+        "list_available_atari_envs",
+        "make_atari_vector_env",
+        "make_humanoid_env",
+        "make_half_cheetah_env",
+        "GymImageEnv",
+        "make_gym_env",
+        "UnityMLAgentsEnv",
+        "make_unity_mlagents_env",
+        "DeepMindControlEnv",
+        "TimeLimit",
+        "ActionRepeat",
+        "NormalizeActions",
+        "ObsDict",
+        "OneHotAction",
+        "RewardObs",
+        "ResizeImage",
+        "RenderImage",
+        "SelectAction",
+    ):
+        from world_models import envs as _envs
+
+        return getattr(_envs, name)
+
+    # Inference Operators
+    if name in (
+        "OperatorABC",
+        "DreamerOperator",
+        "JEPAOperator",
+        "IrisOperator",
+        "PlaNetOperator",
+        "get_operator",
+    ):
+        from world_models.inference import operators as _ops
+
+        return getattr(_ops, name)
+
+    # Reward Models
+    if name in ("RewardModel", "ValueModel"):
+        from world_models import reward as _reward
+
+        return getattr(_reward, name)
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = [
+    # Version
+    "__version__",
+    # Models & Agents
+    "Dreamer",
+    "Planet",
+    "DreamerAgent",
+    "JEPAAgent",
+    "VisionTransformer",
+    "ModularRSSM",
+    "create_modular_rssm",
+    # Configs
+    "DreamerConfig",
+    "JEPAConfig",
+    "DiTConfig",
+    "get_dit_config",
+    "DiamondConfig",
+    "IRISConfig",
+    "ATARI_100K_GAMES",
+    "HUMAN_SCORES",
+    "RANDOM_SCORES",
+    # Environments
+    "make_atari_env",
+    "list_available_atari_envs",
+    "make_atari_vector_env",
+    "make_humanoid_env",
+    "make_half_cheetah_env",
+    "GymImageEnv",
+    "make_gym_env",
+    "UnityMLAgentsEnv",
+    "make_unity_mlagents_env",
+    "DeepMindControlEnv",
+    "TimeLimit",
+    "ActionRepeat",
+    "NormalizeActions",
+    "ObsDict",
+    "OneHotAction",
+    "RewardObs",
+    "ResizeImage",
+    "RenderImage",
+    "SelectAction",
+    # Inference Operators
+    "OperatorABC",
+    "DreamerOperator",
+    "JEPAOperator",
+    "IrisOperator",
+    "PlaNetOperator",
+    # Reward Models
+    "RewardModel",
+    "ValueModel",
+]

--- a/world_models/envs/dmc.py
+++ b/world_models/envs/dmc.py
@@ -1,4 +1,4 @@
-import gym
+import gymnasium as gym
 import numpy as np
 
 
@@ -11,7 +11,6 @@ class DeepMindControlEnv:
     """
 
     def __init__(self, name, seed, size=(64, 64), camera=None):
-
         domain, task = name.split("-", 1)
         if domain == "cup":  # Only domain with multiple words.
             domain = "ball_in_cup"

--- a/world_models/envs/gym_env.py
+++ b/world_models/envs/gym_env.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import gym
+import gymnasium as gym
 import numpy as np
 from PIL import Image
 

--- a/world_models/envs/unity_env.py
+++ b/world_models/envs/unity_env.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import gym
+import gymnasium as gym
 import numpy as np
 from PIL import Image
 

--- a/world_models/envs/wrappers.py
+++ b/world_models/envs/wrappers.py
@@ -1,4 +1,4 @@
-import gym
+import gymnasium as gym
 from PIL import Image
 import numpy as np
 import datetime
@@ -211,9 +211,8 @@ class ResizeImage:
             for k, v in env.obs_space.items()
             if len(v.shape) > 1 and v.shape[:2] != size
         ]
-        print(f'Resizing keys {",".join(self._keys)} to {self._size}.')
+        print(f"Resizing keys {','.join(self._keys)} to {self._size}.")
         if self._keys:
-
             self._Image = Image
 
     def __getattr__(self, name):

--- a/world_models/inference/operators/__init__.py
+++ b/world_models/inference/operators/__init__.py
@@ -4,10 +4,39 @@ from .jepa_operator import JEPAOperator
 from .iris_operator import IrisOperator
 from .planet_operator import PlaNetOperator
 
+
+def get_operator(name: str, **kwargs):
+    """Factory function to get inference operators by name.
+
+    Args:
+        name: One of 'dreamer', 'jepa', 'iris', 'planet'
+        **kwargs: Operator-specific configuration
+
+    Returns:
+        Configured OperatorABC instance
+
+    Example:
+        >>> op = get_operator('dreamer', image_size=64, action_dim=6)
+        >>> processed = op.process({'image': image, 'action': action})
+    """
+    operators = {
+        "dreamer": DreamerOperator,
+        "jepa": JEPAOperator,
+        "iris": IrisOperator,
+        "planet": PlaNetOperator,
+    }
+    if name.lower() not in operators:
+        raise ValueError(
+            f"Unknown operator {name!r}. Available: {list(operators.keys())}"
+        )
+    return operators[name.lower()](**kwargs)
+
+
 __all__ = [
     "OperatorABC",
     "DreamerOperator",
     "JEPAOperator",
     "IrisOperator",
     "PlaNetOperator",
+    "get_operator",
 ]


### PR DESCRIPTION
## Summary
- Add clean public API with lazy imports in `world_models/__init__.py` (43 exports)
- Migrate `gym` → `gymnasium` in environment modules
- Add `get_operator()` factory in inference.operators
- Auto-read version from package in docs/conf.py

## Changes
| File | Change |
|------|-------|
| `world_models/__init__.py` | Public API with lazy imports |
| `world_models/envs/*.py` | gym → gymnasium |
| `world_models/inference/operators/__init__.py` | Factory `get_operator()` |
| `docs/source/conf.py` | Auto-version from package |

## Usage
```python
from world_models import DreamerAgent, DreamerConfig
agent = DreamerAgent(DreamerConfig())
agent.train()

from world_models import get_operator
op = get_operator('dreamer', image_size=64, action_dim=6)
```