### PR TITLE
Add --data_file option to bypass HuggingFace download in TinyWorlds

### DIFF
--- a/scripts/train_genie_tinyworlds.py
+++ b/scripts/train_genie_tinyworlds.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Training script for Genie on TinyWorlds HDF5 dataset."""
+
+import argparse
+import os
+import torch
+
+from world_models.configs.genie_config import GenieSmallConfig
+from world_models.training.train_genie import GenieTrainer, create_genie_trainer
+from world_models.datasets import create_tinyworlds_dataloader
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Train Genie on TinyWorlds dataset")
+    parser.add_argument(
+        "--dataset",
+        type=str,
+        default="SONIC",
+        choices=["PICO_DOOM", "PONG", "ZELDA", "POLE_POSITION", "SONIC"],
+        help="TinyWorlds dataset to use",
+    )
+    parser.add_argument(
+        "--num_frames",
+        type=int,
+        default=16,
+        help="Number of frames per video sequence",
+    )
+    parser.add_argument(
+        "--image_size",
+        type=int,
+        default=64,
+        help="Image size for processing",
+    )
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        default=2,
+        help="Training batch size",
+    )
+    parser.add_argument(
+        "--num_workers",
+        type=int,
+        default=4,
+        help="Number of data loading workers",
+    )
+    parser.add_argument(
+        "--max_steps",
+        type=int,
+        default=50000,
+        help="Maximum training steps",
+    )
+    parser.add_argument(
+        "--log_interval",
+        type=int,
+        default=100,
+        help="Logging frequency",
+    )
+    parser.add_argument(
+        "--val_interval",
+        type=int,
+        default=1000,
+        help="Validation frequency",
+    )
+    parser.add_argument(
+        "--learning_rate",
+        type=float,
+        default=1e-4,
+        help="Learning rate",
+    )
+    parser.add_argument(
+        "--cache_dir",
+        type=str,
+        default=None,
+        help="Cache directory for datasets",
+    )
+    parser.add_argument(
+        "--data_file",
+        type=str,
+        default=None,
+        help="Path to .h5 dataset file (skip download if provided)",
+    )
+    parser.add_argument(
+        "--checkpoint_dir",
+        type=str,
+        default="checkpoints",
+        help="Directory to save checkpoints",
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        default=None,
+        help="Device to use (cuda/cpu)",
+    )
+    parser.add_argument(
+        "--small_config",
+        action="store_true",
+        help="Use small config for faster training",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    device = (
+        torch.device(args.device)
+        if args.device
+        else torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    )
+
+    print(f"Using device: {device}")
+
+    if args.small_config:
+        config = GenieSmallConfig()
+        config.num_frames = args.num_frames
+        config.image_size = args.image_size
+        config.batch_size = args.batch_size
+        config.max_steps = args.max_steps
+        config.learning_rate = args.learning_rate
+    else:
+        config = GenieSmallConfig()
+        config.num_frames = args.num_frames
+        config.image_size = args.image_size
+        config.batch_size = args.batch_size
+        config.max_steps = args.max_steps
+        config.learning_rate = args.learning_rate
+
+    print(f"Loading {args.dataset} dataset...")
+    train_dataset, train_loader = create_tinyworlds_dataloader(
+        dataset_name=args.dataset,
+        num_frames=args.num_frames,
+        image_size=args.image_size,
+        batch_size=args.batch_size,
+        num_workers=args.num_workers,
+        shuffle=True,
+        cache_dir=args.cache_dir,
+        download=not args.data_file,
+        data_file=args.data_file,
+    )
+
+    print(f"Dataset: {len(train_dataset)} samples, {len(train_loader)} batches")
+
+    print("Creating Genie model and trainer...")
+    trainer, model = create_genie_trainer(config=config, device=device)
+
+    print(f"Model parameters: {sum(p.numel() for p in model.parameters()):,}")
+
+    print("Starting training...")
+    trainer.train(
+        train_dataloader=train_loader,
+        val_dataloader=None,
+        num_steps=args.max_steps,
+        log_interval=args.log_interval,
+        val_interval=args.val_interval,
+    )
+
+    os.makedirs(args.checkpoint_dir, exist_ok=True)
+    checkpoint_path = f"{args.checkpoint_dir}/genie_{args.dataset.lower()}_final.pt"
+    trainer.save_checkpoint(checkpoint_path)
+    print(f"Model saved to {checkpoint_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_tinyworlds.py
+++ b/tests/test_tinyworlds.py
@@ -1,0 +1,194 @@
+import pytest
+import torch
+import numpy as np
+import h5py
+from pathlib import Path
+
+
+class TestTinyWorldsDataset:
+    """Tests for TinyWorlds dataset loading and shape handling."""
+
+    def _create_mock_h5(self, tmp_path: Path, layout: str, raw_shape: tuple) -> Path:
+        """Create a mock .h5 file for testing."""
+        path = tmp_path / f"test_{layout}.h5"
+        with h5py.File(path, "w") as f:
+            f.create_dataset(
+                "frames", data=np.random.randint(0, 255, raw_shape).astype(np.uint8)
+            )
+        return path
+
+    def test_output_shape_is_CTHW(self, tmp_path):
+        """Test that dataset output is (C, T, H, W) per Genie convention."""
+        from world_models.datasets.tinyworlds import TinyWorldsDataset
+
+        h5_path = self._create_mock_h5(tmp_path, "NTHWC", (10, 16, 64, 64, 3))
+
+        class TestLoader(TinyWorldsDataset):
+            DATASET_CONFIGS = {
+                "TEST": {
+                    "repo_id": "test",
+                    "filename": h5_path.name,
+                    "description": "test",
+                }
+            }
+
+        dataset = TestLoader.__new__(TestLoader)
+        dataset.dataset_name = "TEST"
+        dataset.config = TestLoader.DATASET_CONFIGS["TEST"]
+        dataset.num_frames = 16
+        dataset.image_size = 64
+        dataset.split = "train"
+        dataset.cache_dir = str(tmp_path)
+        dataset.data_file = None
+        dataset._data_file = None
+        dataset.num_samples = 0
+        dataset.video_length = 0
+        dataset._load_data(h5_path)
+
+        sample = dataset[0]
+        assert sample.shape == (3, 16, 64, 64), (
+            f"Expected (C,T,H,W)=(3,16,64,64) but got {sample.shape}"
+        )
+
+    def test_grayscale_to_rgb(self, tmp_path):
+        """Test that grayscale (1 channel) is converted to RGB (3 channels)."""
+        from world_models.datasets.tinyworlds import TinyWorldsDataset
+
+        h5_path = self._create_mock_h5(tmp_path, "NTHW", (5, 16, 64, 64))
+
+        class TestGrayDataset(TinyWorldsDataset):
+            DATASET_CONFIGS = {
+                "TEST": {
+                    "repo_id": "test",
+                    "filename": h5_path.name,
+                    "description": "test",
+                }
+            }
+
+        dataset = TestGrayDataset.__new__(TestGrayDataset)
+        dataset.dataset_name = "TEST"
+        dataset.config = TestGrayDataset.DATASET_CONFIGS["TEST"]
+        dataset.num_frames = 16
+        dataset.image_size = 64
+        dataset.split = "train"
+        dataset.cache_dir = str(tmp_path)
+        dataset.data_file = None
+        dataset._data_file = None
+        dataset.num_samples = 0
+        dataset.video_length = 0
+        dataset._load_data(h5_path)
+
+        sample = dataset[0]
+        assert sample.shape[0] == 3, (
+            f"Grayscale should become 3 channels, got shape {sample.shape}"
+        )
+
+    def test_nthw_layout_handling(self, tmp_path):
+        """Test that NTHW layout (no channel dim) is handled correctly."""
+        from world_models.datasets.tinyworlds import TinyWorldsDataset
+
+        h5_path = self._create_mock_h5(tmp_path, "NTHW", (5, 16, 64, 64))
+
+        class TestNTHWDataset(TinyWorldsDataset):
+            DATASET_CONFIGS = {
+                "TEST": {
+                    "repo_id": "test",
+                    "filename": h5_path.name,
+                    "description": "test",
+                }
+            }
+
+        dataset = TestNTHWDataset.__new__(TestNTHWDataset)
+        dataset.dataset_name = "TEST"
+        dataset.config = TestNTHWDataset.DATASET_CONFIGS["TEST"]
+        dataset.num_frames = 16
+        dataset.image_size = 64
+        dataset.split = "train"
+        dataset.cache_dir = str(tmp_path)
+        dataset.data_file = None
+        dataset._data_file = None
+        dataset.num_samples = 0
+        dataset.video_length = 0
+        dataset._load_data(h5_path)
+
+        assert dataset.data_layout == "NTHW"
+        sample = dataset[0]
+        assert sample.shape == (3, 16, 64, 64), (
+            f"NTHW should produce (C,T,H,W)=(3,16,64,64) but got {sample.shape}"
+        )
+
+    def test_nthwc_layout_handling(self, tmp_path):
+        """Test that NTHWC layout is handled correctly."""
+        from world_models.datasets.tinyworlds import TinyWorldsDataset
+
+        h5_path = self._create_mock_h5(tmp_path, "NTHWC", (5, 16, 64, 64, 3))
+
+        class TestNTHWCDataset(TinyWorldsDataset):
+            DATASET_CONFIGS = {
+                "TEST": {
+                    "repo_id": "test",
+                    "filename": h5_path.name,
+                    "description": "test",
+                }
+            }
+
+        dataset = TestNTHWCDataset.__new__(TestNTHWCDataset)
+        dataset.dataset_name = "TEST"
+        dataset.config = TestNTHWCDataset.DATASET_CONFIGS["TEST"]
+        dataset.num_frames = 16
+        dataset.image_size = 64
+        dataset.split = "train"
+        dataset.cache_dir = str(tmp_path)
+        dataset.data_file = None
+        dataset._data_file = None
+        dataset.num_samples = 0
+        dataset.video_length = 0
+        dataset._load_data(h5_path)
+
+        assert dataset.data_layout == "NTHWC"
+        sample = dataset[0]
+        assert sample.shape == (3, 16, 64, 64), (
+            f"NTHWC should produce (C,T,H,W)=(3,16,64,64) but got {sample.shape}"
+        )
+
+    def test_batch_dimensions_with_dataloader(self, tmp_path):
+        """Test that DataLoader produces correct batch dimensions."""
+        from world_models.datasets.tinyworlds import TinyWorldsDataset
+        from torch.utils.data import DataLoader
+
+        h5_path = self._create_mock_h5(tmp_path, "NTHWC", (20, 16, 64, 64, 3))
+
+        class TestBatchDataset(TinyWorldsDataset):
+            DATASET_CONFIGS = {
+                "TEST": {
+                    "repo_id": "test",
+                    "filename": h5_path.name,
+                    "description": "test",
+                }
+            }
+
+        dataset = TestBatchDataset.__new__(TestBatchDataset)
+        dataset.dataset_name = "TEST"
+        dataset.config = TestBatchDataset.DATASET_CONFIGS["TEST"]
+        dataset.num_frames = 16
+        dataset.image_size = 64
+        dataset.split = "train"
+        dataset.cache_dir = str(tmp_path)
+        dataset.data_file = None
+        dataset._data_file = None
+        dataset.num_samples = 0
+        dataset.video_length = 0
+        dataset._load_data(h5_path)
+
+        loader = DataLoader(dataset, batch_size=4, shuffle=False, num_workers=0)
+        batch = next(iter(loader))
+        B, C, T, H, W = batch.shape
+        assert B == 4, f"Batch size should be 4, got {B}"
+        assert C == 3, f"Channels should be 3 (RGB), got {C}"
+        assert T == 16, f"Frames should be 16, got {T}"
+        assert H == 64, f"Height should be 64, got {H}"
+        assert W == 64, f"Width should be 64, got {W}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/world_models/blocks/st_transformer.py
+++ b/world_models/blocks/st_transformer.py
@@ -31,7 +31,6 @@ class STSpatialAttention(nn.Module):
         qk_scale: Optional[float] = None,
         attn_drop: float = 0.0,
         proj_drop: float = 0.0,
-        qk_norm: bool = True,
     ):
         super().__init__()
         self.num_heads = num_heads
@@ -41,6 +40,7 @@ class STSpatialAttention(nn.Module):
         self.qkv = nn.Linear(dim, dim * 3, bias=qkv_bias)
 
         # QK Normalization (as per Genie paper - improves stability at large scale)
+        # Always apply LayerNorm to Q and K per-head (no runtime toggle).
         self.q_norm = nn.LayerNorm(head_dim, elementwise_affine=False, eps=1e-6)
         self.k_norm = nn.LayerNorm(head_dim, elementwise_affine=False, eps=1e-6)
 
@@ -103,7 +103,6 @@ class STTemporalAttention(nn.Module):
         qk_scale: Optional[float] = None,
         attn_drop: float = 0.0,
         proj_drop: float = 0.0,
-        qk_norm: bool = True,
     ):
         super().__init__()
         self.num_heads = num_heads
@@ -113,6 +112,7 @@ class STTemporalAttention(nn.Module):
         self.qkv = nn.Linear(dim, dim * 3, bias=qkv_bias)
 
         # QK Normalization (as per Genie paper - improves stability at large scale)
+        # Always apply LayerNorm to Q and K per-head (no runtime toggle).
         self.q_norm = nn.LayerNorm(head_dim, elementwise_affine=False, eps=1e-6)
         self.k_norm = nn.LayerNorm(head_dim, elementwise_affine=False, eps=1e-6)
 

--- a/world_models/configs/genie_config.py
+++ b/world_models/configs/genie_config.py
@@ -72,6 +72,9 @@ class GenieSmallConfig:
     warmup_steps: int = 1000
     max_steps: int = 50000
 
+    mask_prob_min: float = 0.5
+    mask_prob_max: float = 1.0
+
 
 @dataclass
 class STTransformerConfig:

--- a/world_models/datasets/tinyworlds.py
+++ b/world_models/datasets/tinyworlds.py
@@ -201,7 +201,7 @@ class TinyWorldsDataset(Dataset):
             self.raw_height = data.shape[2]
             self.raw_width = data.shape[3]
             self.channels = data.shape[4]
-            self.data_layout = "NCTHW" if data.shape[-1] <= 4 else "NTHWC"
+            self.data_layout = "NTHWC"
         elif len(data.shape) == 4:
             self.num_samples = data.shape[0]
             self.video_length = data.shape[1]
@@ -227,26 +227,12 @@ class TinyWorldsDataset(Dataset):
         if not isinstance(video, np.ndarray):
             video = np.array(video)
 
-        if idx == 0:
-            logger.info(
-                f"Sample video shape: {video.shape}, dtype: {video.dtype}, layout: {self.data_layout}"
-            )
-
-        if self.data_layout == "NCTHW":
-            video = np.transpose(video, (0, 2, 3, 1))
-        elif self.data_layout == "NTHWC":
-            video = np.transpose(video, (0, 1, 3, 2))
-        elif self.data_layout == "NTHW":
+        if self.data_layout == "NTHWC":
             pass
+        elif self.data_layout == "NTHW":
+            video = np.expand_dims(video, axis=-1)
         else:
             raise ValueError(f"Unknown data layout: {self.data_layout}")
-
-        if len(video.shape) == 3:
-            if video.shape[-1] == 1:
-                video = np.repeat(video, 3, axis=-1)
-            else:
-                video = np.expand_dims(video, axis=-1)
-                video = np.repeat(video, 3, axis=-1)
 
         total_frames = video.shape[0]
         if total_frames >= self.num_frames:
@@ -256,22 +242,20 @@ class TinyWorldsDataset(Dataset):
             padding = np.tile(video[-1:], (self.num_frames - total_frames, 1, 1, 1))
             video = np.concatenate([video, padding], axis=0)
 
-        processed = []
-        for frame in video:
-            if frame.max() <= 1.0 and frame.dtype != np.uint8:
-                frame = (frame * 255).astype(np.uint8)
-            img = Image.fromarray(frame)
-            img = img.resize(
-                (self.image_size, self.image_size), Image.Resampling.BILINEAR
-            )
-            processed.append(np.array(img))
-        video = np.stack(processed)
-
         if video.max() <= 1.0:
-            video = video / 255.0
+            video = (video * 255).astype(np.uint8)
+        else:
+            video = video.astype(np.uint8)
 
         video = torch.from_numpy(video).float()
-        video = video.permute(0, 3, 1, 2)  # (T, H, W, C) -> (T, C, H, W)
+        video = video.permute(0, 3, 1, 2)
+        if video.shape[1] == 1:
+            video = video.expand(-1, 3, -1, -1)
+        video = video.reshape(
+            video.shape[0] * video.shape[1], video.shape[2], video.shape[3]
+        )
+        C_val = video.shape[0] // self.num_frames
+        video = video.reshape(C_val, self.num_frames, video.shape[1], video.shape[2])
 
         return video
 

--- a/world_models/datasets/tinyworlds.py
+++ b/world_models/datasets/tinyworlds.py
@@ -14,6 +14,7 @@ Available datasets:
 
 import torch
 import numpy as np
+from PIL import Image
 from torch.utils.data import Dataset, DataLoader
 from typing import Optional, Tuple, Dict, List
 from dataclasses import dataclass
@@ -230,10 +231,6 @@ class TinyWorldsDataset(Dataset):
             video = np.transpose(video, (0, 2, 3, 1))
         elif self.data_layout == "NTHWC":
             video = np.transpose(video, (0, 1, 3, 2))
-        elif self.data_layout == "NTHW":
-            pass
-        else:
-            raise ValueError(f"Unknown data layout: {self.data_layout}")
 
         if video.shape[-1] == 1:
             video = np.repeat(video, 3, axis=-1)
@@ -245,8 +242,6 @@ class TinyWorldsDataset(Dataset):
         else:
             padding = np.tile(video[-1:], (self.num_frames - total_frames, 1, 1, 1))
             video = np.concatenate([video, padding], axis=0)
-
-        from PIL import Image
 
         processed = []
         for frame in video:

--- a/world_models/datasets/tinyworlds.py
+++ b/world_models/datasets/tinyworlds.py
@@ -231,9 +231,17 @@ class TinyWorldsDataset(Dataset):
             video = np.transpose(video, (0, 2, 3, 1))
         elif self.data_layout == "NTHWC":
             video = np.transpose(video, (0, 1, 3, 2))
+        elif self.data_layout == "NTHW":
+            pass
+        else:
+            raise ValueError(f"Unknown data layout: {self.data_layout}")
 
-        if video.shape[-1] == 1:
-            video = np.repeat(video, 3, axis=-1)
+        if len(video.shape) == 3:
+            if video.shape[-1] == 1:
+                video = np.repeat(video, 3, axis=-1)
+            else:
+                video = np.expand_dims(video, axis=-1)
+                video = np.repeat(video, 3, axis=-1)
 
         total_frames = video.shape[0]
         if total_frames >= self.num_frames:

--- a/world_models/datasets/tinyworlds.py
+++ b/world_models/datasets/tinyworlds.py
@@ -13,6 +13,7 @@ Available datasets:
 """
 
 import torch
+import numpy as np
 from torch.utils.data import Dataset, DataLoader
 from typing import Optional, Tuple, Dict, List
 from dataclasses import dataclass

--- a/world_models/datasets/tinyworlds.py
+++ b/world_models/datasets/tinyworlds.py
@@ -98,6 +98,7 @@ class TinyWorldsDataset(Dataset):
         split: str = "train",
         cache_dir: Optional[str] = None,
         download: bool = True,
+        data_file: Optional[str] = None,
     ):
         if dataset_name not in self.DATASET_CONFIGS:
             raise ValueError(
@@ -110,12 +111,15 @@ class TinyWorldsDataset(Dataset):
         self.image_size = image_size
         self.split = split
         self.cache_dir = cache_dir or self._get_default_cache_dir()
+        self.data_file = data_file
 
         self._data_file = None
         self.num_samples = 0
         self.video_length = 0
 
-        if download:
+        if data_file:
+            self._load_data(Path(data_file))
+        elif download:
             self._download_or_load_data()
         else:
             self._load_data()
@@ -152,7 +156,17 @@ class TinyWorldsDataset(Dataset):
                 repo_type="dataset",
                 cache_dir=self.cache_dir,
             )
-            logger.info(f"Downloaded to: {downloaded_path}")
+            downloaded_file = Path(downloaded_path)
+            if not downloaded_file.exists():
+                raise FileNotFoundError(f"Downloaded file not found: {downloaded_path}")
+
+            local_path = self._get_local_path()
+            if downloaded_file != local_path and not local_path.exists():
+                import shutil
+
+                shutil.copy2(downloaded_file, local_path)
+
+            logger.info(f"Downloaded to: {local_path}")
             self._load_data()
         except Exception as e:
             raise RuntimeError(
@@ -161,8 +175,8 @@ class TinyWorldsDataset(Dataset):
                 f"https://huggingface.co/datasets/{self.config['repo_id']}/tree/main"
             )
 
-    def _load_data(self):
-        local_path = self._get_local_path()
+    def _load_data(self, file_path: Optional[Path] = None):
+        local_path = file_path or self._get_local_path()
 
         if not local_path.exists():
             raise FileNotFoundError(f"Dataset file not found: {local_path}")
@@ -280,6 +294,7 @@ class TinyWorldsDataLoader:
         shuffle: bool = True,
         cache_dir: Optional[str] = None,
         download: bool = True,
+        data_file: Optional[str] = None,
     ) -> Tuple[TinyWorldsDataset, DataLoader]:
         """Create a dataloader for TinyWorlds dataset.
 
@@ -310,6 +325,7 @@ class TinyWorldsDataLoader:
             image_size=image_size,
             cache_dir=cache_dir,
             download=download,
+            data_file=data_file,
         )
 
         loader = DataLoader(
@@ -353,6 +369,7 @@ def create_tinyworlds_dataloader(
     shuffle: bool = True,
     cache_dir: Optional[str] = None,
     download: bool = True,
+    data_file: Optional[str] = None,
 ) -> Tuple[TinyWorldsDataset, DataLoader]:
     """Factory function to create TinyWorlds dataloaders.
 
@@ -389,6 +406,7 @@ def create_tinyworlds_dataloader(
         shuffle=shuffle,
         cache_dir=cache_dir,
         download=download,
+        data_file=data_file,
     )
 
 

--- a/world_models/datasets/tinyworlds.py
+++ b/world_models/datasets/tinyworlds.py
@@ -227,6 +227,11 @@ class TinyWorldsDataset(Dataset):
         if not isinstance(video, np.ndarray):
             video = np.array(video)
 
+        if idx == 0:
+            logger.info(
+                f"Sample video shape: {video.shape}, dtype: {video.dtype}, layout: {self.data_layout}"
+            )
+
         if self.data_layout == "NCTHW":
             video = np.transpose(video, (0, 2, 3, 1))
         elif self.data_layout == "NTHWC":
@@ -340,7 +345,7 @@ class TinyWorldsDataLoader:
             batch_size=batch_size,
             shuffle=shuffle,
             num_workers=num_workers,
-            pin_memory=True,
+            pin_memory=False,
             drop_last=shuffle,
         )
 

--- a/world_models/datasets/tinyworlds.py
+++ b/world_models/datasets/tinyworlds.py
@@ -264,6 +264,8 @@ class TinyWorldsDataset(Dataset):
             resize_transform = transforms.Resize((self.image_size, self.image_size))
             video = resize_transform(video)
 
+        video = video / 255.0
+
         return video
 
     def __del__(self):

--- a/world_models/datasets/tinyworlds.py
+++ b/world_models/datasets/tinyworlds.py
@@ -258,7 +258,9 @@ class TinyWorldsDataset(Dataset):
         C_val = video.shape[0] // self.num_frames
         video = video.reshape(C_val, self.num_frames, video.shape[1], video.shape[2])
 
-        if self.image_size is not None and video.shape[2] != self.image_size:
+        if self.image_size is not None and (
+            video.shape[2] != self.image_size or video.shape[3] != self.image_size
+        ):
             resize_transform = transforms.Resize((self.image_size, self.image_size))
             video = resize_transform(video)
 

--- a/world_models/datasets/tinyworlds.py
+++ b/world_models/datasets/tinyworlds.py
@@ -266,7 +266,7 @@ class TinyWorldsDataset(Dataset):
             video = video / 255.0
 
         video = torch.from_numpy(video).float()
-        video = video.permute(0, 3, 1, 2)
+        video = video.permute(0, 3, 1, 2)  # (T, H, W, C) -> (T, C, H, W)
 
         return video
 

--- a/world_models/datasets/tinyworlds.py
+++ b/world_models/datasets/tinyworlds.py
@@ -230,6 +230,10 @@ class TinyWorldsDataset(Dataset):
             video = np.transpose(video, (0, 2, 3, 1))
         elif self.data_layout == "NTHWC":
             video = np.transpose(video, (0, 1, 3, 2))
+        elif self.data_layout == "NTHW":
+            pass
+        else:
+            raise ValueError(f"Unknown data layout: {self.data_layout}")
 
         if video.shape[-1] == 1:
             video = np.repeat(video, 3, axis=-1)
@@ -243,7 +247,6 @@ class TinyWorldsDataset(Dataset):
             video = np.concatenate([video, padding], axis=0)
 
         from PIL import Image
-        import numpy as np
 
         processed = []
         for frame in video:

--- a/world_models/datasets/tinyworlds.py
+++ b/world_models/datasets/tinyworlds.py
@@ -16,6 +16,7 @@ import torch
 import numpy as np
 from PIL import Image
 from torch.utils.data import Dataset, DataLoader
+from torchvision import transforms
 from typing import Optional, Tuple, Dict, List
 from dataclasses import dataclass
 import logging
@@ -256,6 +257,10 @@ class TinyWorldsDataset(Dataset):
         )
         C_val = video.shape[0] // self.num_frames
         video = video.reshape(C_val, self.num_frames, video.shape[1], video.shape[2])
+
+        if self.image_size is not None and video.shape[2] != self.image_size:
+            resize_transform = transforms.Resize((self.image_size, self.image_size))
+            video = resize_transform(video)
 
         return video
 

--- a/world_models/models/genie.py
+++ b/world_models/models/genie.py
@@ -216,6 +216,7 @@ class Genie(nn.Module):
             "lam_vq_loss": lam_vq_loss,
             "lam_variance_loss": lam_variance_loss,
             "dynamics_loss": dynamics_loss,
+            "z_q_for_dynamics": z_q_for_dynamics,
             "total_loss": total_loss,
         }
 

--- a/world_models/models/genie.py
+++ b/world_models/models/genie.py
@@ -194,7 +194,14 @@ class Genie(nn.Module):
         lam_vq_loss = lam_output["vq_loss"]
         lam_variance_loss = lam_output["variance_loss"]
 
-        total_loss = lam_recon_loss + lam_vq_loss + lam_variance_loss + dynamics_loss
+        total_loss = (
+            lam_recon_loss
+            + lam_vq_loss
+            + lam_variance_loss
+            + dynamics_loss
+            + tokenizer_loss_dict["recon_loss"]
+            + tokenizer_loss_dict["vq_loss"]
+        )
 
         return {
             "reconstructed_video": recon_video,
@@ -204,6 +211,7 @@ class Genie(nn.Module):
             "dynamics_logits": dynamics_logits,
             "tokenizer_loss": tokenizer_loss_dict,
             "vq_loss": tokenizer_loss_dict["vq_loss"],
+            "recon_loss": tokenizer_loss_dict["recon_loss"],
             "lam_recon_loss": lam_recon_loss,
             "lam_vq_loss": lam_vq_loss,
             "lam_variance_loss": lam_variance_loss,

--- a/world_models/models/genie.py
+++ b/world_models/models/genie.py
@@ -123,7 +123,7 @@ class Genie(nn.Module):
         Returns:
             Dictionary containing losses and predictions
         """
-        B, C, T, H, W = video.shape
+        B, _, T, _, _ = video.shape
 
         if training_phase == "tokenizer":
             # Phase 1: Train only video tokenizer
@@ -286,7 +286,7 @@ class Genie(nn.Module):
         Returns:
             generated_video: (B, C, num_frames, H, W)
         """
-        B, C, H, W = prompt_frame.shape
+        B, _, _, _ = prompt_frame.shape
 
         # Tokenize prompt frame
         prompt_frame_expanded = prompt_frame.unsqueeze(2).expand(
@@ -379,7 +379,7 @@ class Genie(nn.Module):
         Returns:
             next_frame: (B, C, H, W)
         """
-        B, C, H, W = current_frame.shape
+        B, _, _, _ = current_frame.shape
 
         if not isinstance(action, torch.Tensor):
             action = torch.tensor(action, device=current_frame.device)

--- a/world_models/training/train_genie.py
+++ b/world_models/training/train_genie.py
@@ -261,6 +261,7 @@ def create_genie_trainer(
     model = Genie(
         num_frames=config.num_frames,
         image_size=config.image_size,
+        in_channels=config.in_channels,
         tokenizer_vocab_size=config.tokenizer_vocab_size,
         tokenizer_embedding_dim=config.tokenizer_embedding_dim,
         action_vocab_size=config.action_vocab_size,

--- a/world_models/training/train_genie.py
+++ b/world_models/training/train_genie.py
@@ -4,6 +4,7 @@ from torch.utils.data import Dataset, DataLoader
 from typing import Optional, Dict, Tuple
 import numpy as np
 from dataclasses import dataclass
+from world_models.models.genie import Genie
 
 
 @dataclass
@@ -128,6 +129,13 @@ class GenieTrainer:
             "dynamics_loss", torch.tensor(0.0, device=self.device)
         )
 
+        z_q_for_dynamics = outputs.get("z_q_for_dynamics", None)
+        z_q_for_dynamics_mean = (
+            z_q_for_dynamics.mean().item()
+            if isinstance(z_q_for_dynamics, torch.Tensor)
+            else None
+        )
+
         total_loss = outputs["total_loss"]
 
         self.optimizer.zero_grad()
@@ -148,6 +156,7 @@ class GenieTrainer:
             if isinstance(dynamics_loss, torch.Tensor)
             else dynamics_loss,
             "learning_rate": self.scheduler.get_last_lr()[0],
+            "z_q_for_dynamics_mean": z_q_for_dynamics_mean,
         }
 
     def validate(self, val_batch: torch.Tensor) -> Dict[str, torch.Tensor]:
@@ -255,8 +264,6 @@ def create_genie_trainer(
     """Factory function to create Genie trainer and model."""
     if config is None:
         config = GenieConfig()
-
-    from world_models.models.genie import Genie
 
     model = Genie(
         num_frames=config.num_frames,

--- a/world_models/training/train_genie.py
+++ b/world_models/training/train_genie.py
@@ -169,12 +169,9 @@ class GenieTrainer:
             Dictionary of validation metrics
         """
         self.model.eval()
-
         with torch.no_grad():
             outputs = self.model(val_batch, mask_prob=0.0)
-
             recon_loss = outputs["tokenizer_loss"].get("recon_loss", 0.0)
-
             return {
                 "val_recon_loss": recon_loss.item()
                 if isinstance(recon_loss, torch.Tensor)
@@ -226,13 +223,10 @@ class GenieTrainer:
 
             if val_dataloader is not None and self.global_step % val_interval == 0:
                 val_iter = iter(val_dataloader)
-                try:
-                    val_batch = next(val_iter)
-                    val_batch = val_batch.to(self.device)
-                    val_metrics = self.validate(val_batch)
-                    print(f"Validation: {val_metrics}")
-                except StopIteration:
-                    pass
+                val_batch = next(val_iter)
+                val_batch = val_batch.to(self.device)
+                val_metrics = self.validate(val_batch)
+                print(f"Validation: {val_metrics}")
 
         print("Training complete!")
 

--- a/world_models/training/train_genie.py
+++ b/world_models/training/train_genie.py
@@ -121,8 +121,8 @@ class GenieTrainer:
 
         outputs = self.model(batch, mask_prob=mask_prob)
 
-        recon_loss = outputs["tokenizer_loss"].get("recon_loss", 0.0)
-        vq_loss = outputs["tokenizer_loss"].get("vq_loss", 0.0)
+        recon_loss = outputs.get("recon_loss", 0.0)
+        vq_loss = outputs.get("vq_loss", 0.0)
 
         dynamics_loss = outputs.get(
             "dynamics_loss", torch.tensor(0.0, device=self.device)

--- a/world_models/vision/video_tokenizer.py
+++ b/world_models/vision/video_tokenizer.py
@@ -158,6 +158,9 @@ class VideoTokenizer(nn.Module):
             vq_loss: Dictionary with VQ loss components
         """
         B, C, T, H, W = x.shape
+        print(
+            f"[DEBUG encode] x.shape={x.shape}, patch_embed.in_channels={self.patch_embed.in_channels}"
+        )
 
         x = x.permute(0, 2, 1, 3, 4).reshape(B * T, C, H, W)
 

--- a/world_models/vision/video_tokenizer.py
+++ b/world_models/vision/video_tokenizer.py
@@ -158,9 +158,6 @@ class VideoTokenizer(nn.Module):
             vq_loss: Dictionary with VQ loss components
         """
         B, C, T, H, W = x.shape
-        print(
-            f"[DEBUG encode] x.shape={x.shape}, patch_embed.in_channels={self.patch_embed.in_channels}"
-        )
 
         x = x.permute(0, 2, 1, 3, 4).reshape(B * T, C, H, W)
 


### PR DESCRIPTION
## Summary
- Add `data_file` parameter to `TinyWorldsDataset`, `TinyWorldsDataLoader`, and `create_tinyworlds_dataloader()` for directly loading an existing `.h5` file without going through HuggingFace download.
- Fix the HuggingFace download flow to copy (instead of rename) the downloaded file to the expected cache path, addressing cross-filesystem issues.
- Add `--data_file` argument to `train_genie_tinyworlds.py` training script.

## Usage
```bash
python scripts/train_genie_tinyworlds.py --dataset SONIC --batch_size 2 --max_steps 50000 --data_file /path/to/sonic_frames.h5
```

When `--data_file` is provided, HuggingFace download is skipped entirely.