### PR TITLE
Add `gpu` install extra and document CPU/GPU install paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,11 @@ Train Dreamer agents in just 3 lines of code. TorchWM provides a unified interfa
 ### Installation
 
 ```bash
-# Core dependencies
+# CPU build (default)
 pip install torchwm
+
+# GPU build
+pip install torchwm[gpu]
 
 # With extras
 pip install torchwm[gym]       # Additional gym environments
@@ -30,6 +33,11 @@ pip install torchwm[ml]        # TensorBoard, W&B logging
 pip install torchwm[viz]       # FastAPI visualization
 pip install torchwm[dev]       # Testing and linting
 ```
+
+TorchWM keeps `pip install torchwm` CPU-first for portable installs. Use
+`pip install torchwm[gpu]` when you want the CUDA-enabled PyTorch stack; with
+`uv`, TorchWM no longer forces the CUDA PyTorch index for default installs and
+switches to the CUDA 12.1 PyTorch index when the `gpu` extra is requested.
 
 ### Training a Dreamer Agent
 
@@ -204,9 +212,11 @@ TorchWM provides a unified interface for training and deploying world models.
 ### Installation
 
 ```bash
+# CPU build (default)
 pip install torchwm
-# or with uv
-uv add torch torchvision torchaudio
+
+# GPU build
+pip install torchwm[gpu]
 ```
 
 ### Training a Dreamer Agent

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -5,8 +5,16 @@
 Install from PyPI:
 
 ```bash
+# CPU build (default)
 pip install torchwm
+
+# GPU build
+pip install torchwm[gpu]
 ```
+
+Use `pip install torchwm` for the CPU-compatible default install. Use
+`pip install torchwm[gpu]` on GPU machines when you want the CUDA-enabled
+PyTorch stack.
 
 Install from source:
 

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -7,8 +7,11 @@ TorchWM supports multiple installation methods depending on your use case.
 For stable releases:
 
 ```bash
-# Core dependencies (torch, torchvision, torchaudio, gym, gymnasium, etc.)
+# CPU build (default core dependencies: torch, torchvision, torchaudio, gym, etc.)
 pip install torchwm
+
+# GPU build (CUDA-enabled PyTorch stack)
+pip install torchwm[gpu]
 
 # With specific extras
 pip install torchwm[gym]       # Additional gym environments (huggingface-hub, pygame, autorom)
@@ -19,13 +22,14 @@ pip install torchwm[docs]      # Sphinx and documentation tools
 pip install torchwm[dev]       # Testing and development tools (pytest, mypy, pre-commit)
 
 # Install multiple extras
-pip install torchwm[gym,ml-agents,dev]
+pip install torchwm[gpu,gym,ml-agents,dev]
 ```
 
 ### Available Extras
 
 | Extra | Description |
 |-------|-------------|
+| `gpu` | CUDA-enabled PyTorch, torchvision, and torchaudio stack |
 | `gym` | Additional Gym environment dependencies (huggingface-hub, pygame, autorom) |
 | `ml-agents` | Unity ML-Agents support |
 | `ml` | TensorBoard, Weights & Biases, and logging tools |
@@ -52,17 +56,21 @@ pip install -e .
 pip install -e ".[gym,ml-agents,ml,viz,dev,docs]"
 ```
 
-## CUDA Support
+## CPU and CUDA PyTorch Selection
 
-For GPU acceleration, install PyTorch with CUDA:
+TorchWM installs the CPU-compatible PyTorch stack by default so `pip install torchwm`
+works consistently on machines without a GPU. If a GPU is available and you want
+CUDA acceleration, request the GPU extra:
 
 ```bash
-# Using uv (recommended)
-uv add torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
-
-# Or using pip
-pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
+pip install torchwm[gpu]
 ```
+
+When installing with `uv`, TorchWM's project metadata no longer forces the CUDA
+PyTorch index for default installs, and routes the `gpu` extra to the CUDA 12.1
+PyTorch wheel index. If your environment needs a different CUDA wheel family,
+install the matching PyTorch packages from the official PyTorch index before
+installing TorchWM.
 
 ## Docker
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,11 @@ dependencies = [
 torchwm = "tools.cli:run"
 
 [project.optional-dependencies]
+gpu = [
+    "torch>=1.13.0",
+    "torchvision>=0.14.0",
+    "torchaudio>=2.10.0",
+]
 gym = [
     "huggingface-hub>=0.23.0",
     "pygame>=2.6.1",
@@ -79,13 +84,17 @@ docs = [
 ]
 
 [tool.uv]
-index-url = "https://download.pytorch.org/whl/cu121"
-extra-index-url = ["https://pypi.org/simple"]
 index-strategy = "unsafe-best-match"
 
+[tool.uv.sources]
+torch = { index = "pytorch-cu121", extra = "gpu" }
+torchvision = { index = "pytorch-cu121", extra = "gpu" }
+torchaudio = { index = "pytorch-cu121", extra = "gpu" }
+
 [[tool.uv.index]]
+name = "pytorch-cu121"
 url = "https://download.pytorch.org/whl/cu121"
-default = true
+explicit = true
 
 [build-system]
 requires = ["setuptools>=61.0", "wheel", "build"]

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,11 @@ setup(
         "tqdm>=4.67.1",
     ],
     extras_require={
+        "gpu": [
+            "torch>=1.13.0",
+            "torchvision>=0.14.0",
+            "torchaudio>=2.10.0",
+        ],
         "gym": [
             "ale-py>=0.11.2",
             "gym>=0.26.2",

--- a/uv.lock
+++ b/uv.lock
@@ -3646,6 +3646,11 @@ docs = [
     { name = "sphinxcontrib-mermaid" },
     { name = "sphinxext-opengraph" },
 ]
+gpu = [
+    { name = "torch" },
+    { name = "torchaudio" },
+    { name = "torchvision" },
+]
 gym = [
     { name = "autorom" },
     { name = "huggingface-hub" },
@@ -3705,8 +3710,11 @@ requires-dist = [
     { name = "sphinxext-opengraph", marker = "extra == 'docs'", specifier = ">=0.13.0" },
     { name = "tensorboard", marker = "extra == 'ml'", specifier = ">=2.20.0" },
     { name = "tensorboardx", marker = "extra == 'ml'", specifier = ">=2.6.4" },
+    { name = "torch", marker = "extra == 'gpu'", specifier = ">=1.13.0" },
     { name = "torch", specifier = ">=1.13.0" },
+    { name = "torchaudio", marker = "extra == 'gpu'", specifier = ">=2.10.0" },
     { name = "torchaudio", specifier = ">=2.10.0" },
+    { name = "torchvision", marker = "extra == 'gpu'", specifier = ">=0.14.0" },
     { name = "torchvision", specifier = ">=0.14.0" },
     { name = "torchwm", extras = ["gym", "viz", "ml", "ml-agents", "dev", "docs"], marker = "extra == 'all'" },
     { name = "tqdm", specifier = ">=4.67.1" },
@@ -3714,7 +3722,7 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'viz'", specifier = ">=0.35.0" },
     { name = "wandb", marker = "extra == 'ml'", specifier = ">=0.16.0" },
 ]
-provides-extras = ["gym", "ml-agents", "viz", "ml", "dev", "all", "docs"]
+provides-extras = ["gpu", "gym", "ml-agents", "viz", "ml", "dev", "all", "docs"]
 
 [[package]]
 name = "tornado"


### PR DESCRIPTION
### Motivation
- Provide a simple opt-in way to install CUDA-enabled PyTorch wheels when a GPU is available via `pip install torchwm[gpu]` while keeping `pip install torchwm` CPU-first for portable installs.
- Make project metadata and package index routing compatible with `uv` so the CUDA PyTorch index is only used when the `gpu` extra is requested.

### Description
- Add a `gpu` optional-dependency to `pyproject.toml` under `[project.optional-dependencies]` and to `extras_require` in `setup.py` that includes `torch`, `torchvision`, and `torchaudio`.
- Update `uv` configuration in `pyproject.toml` (`[tool.uv]` / `[tool.uv.sources]` and `[[tool.uv.index]]`) so `torch`, `torchvision`, and `torchaudio` are routed to the CUDA 12.1 PyTorch index when the `gpu` extra is requested and are not forced to the CUDA index by default.
- Update documentation: `README.md`, `docs/source/installation.md`, and `docs/source/getting_started.md` now document `pip install torchwm` (CPU/default) and `pip install torchwm[gpu]` (CUDA-enabled) with guidance about `uv` behavior.
- Update the project lock/metadata (`uv.lock` entries) so the new `gpu` extra is reflected and package metadata include `extra == 'gpu'` markers for the PyTorch packages.

### Testing
- Verified `pyproject.toml` parsing and presence of the `gpu` extra with a small `tomllib` validation script (passed).
- Performed an editable-install dry-run with `python -m pip install -e . --dry-run --no-deps --no-build-isolation` which reported the package would install (passed).
- Ran `python setup.py egg_info` which completed and generated metadata (passed).
- Built a source distribution with `uv build --sdist --no-build-isolation` which succeeded and produced `dist/torchwm-*.tar.gz` (passed).
- Ran `uv lock --offline --dry-run` which failed due to the offline lock cache missing `ale-py` for the Python `>=3.14` resolution split; this failure is an offline cache/network issue and not caused by the `gpu` extra change (warning/failure unrelated to metadata changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c42468c8c832e9e1d99e20b9b85fb)