### PR TITLE
Add benchmark command to torchwm CLI

### DIFF
--- a/docs/source/benchmarks.md
+++ b/docs/source/benchmarks.md
@@ -1,133 +1,193 @@
 # Benchmarking World Models
 
-This page documents the lightweight benchmarking harness included in the repository.
+TorchWM includes a lightweight benchmark harness for running standardized
+evaluations of trained world-model agents and exporting results that can be used
+in experiment logs, reports, and papers.
 
-Quick Overview
---------------
+## Quick Overview
+
 - Code lives under `world_models/benchmarks/`.
-- Entrypoints:
-  - CLI: `python -m world_models.benchmarks.cli` (see examples below)
-  - Python API: `world_models.benchmarks.runner.BenchmarkRunner`
+- Preferred CLI entrypoint: `torchwm benchmark`.
+- Module entrypoint: `python -m world_models.benchmarks.cli`.
+- Python API: `world_models.benchmarks.runner.BenchmarkRunner`.
 
-Supported adapters (out of the box)
-----------------------------------
+## Supported adapters
+
+The benchmark CLI currently registers these adapters out of the box:
+
 - `diamond` - DIAMOND diffusion world-model agent (`world_models.training.train_diamond.DiamondAgent`)
 - `iris` - IRIS transformer-based agent (`world_models.training.train_iris.IRISTrainer`)
 - `dreamerv1` / `dreamerv2` - Dreamer family (`world_models.models.dreamer.DreamerAgent`)
 
-CLI Examples
-------------
+Benchmarks are intended for trained models. For single-agent runs, pass a
+checkpoint with `--checkpoint`. For multi-agent runs, pass one or more
+`--checkpoint-map AGENT=PATH` values, or use `--train-epochs` when you
+intentionally want the CLI to train before evaluating.
 
-- Run IRIS on Pong for 3 episodes using seed 0 (writes results to `results/bench` by default):
+## TorchWM CLI examples
 
-```
-python -m world_models.benchmarks.cli --agent iris --game ALE/Pong-v5 --seeds 1 --episodes 3
-```
+Run IRIS on Pong for 3 episodes using seed 0 and write the standard result files
+to `results/bench`:
 
-- Run DIAMOND on Breakout with two explicit seeds and 5 episodes per seed:
-
-```
-python -m world_models.benchmarks.cli --agent diamond --game Breakout-v5 --seeds 0,1 --episodes 5
-```
-
-- Run DreamerV2 on a Gym env (example):
-
-```
-python -m world_models.benchmarks.cli --agent dreamerv2 --game Pong-v5 --seeds 1 --episodes 10
+```bash
+torchwm benchmark \
+  --agent iris \
+  --game ALE/Pong-v5 \
+  --checkpoint checkpoints/iris/pong.pt \
+  --seeds 1 \
+  --episodes 3
 ```
 
-- Run all agents on Pong for 3 episodes using seed 0:
+Run DIAMOND on Breakout with two explicit seeds and 5 episodes per seed:
 
+```bash
+torchwm benchmark \
+  --agent diamond \
+  --game Breakout-v5 \
+  --checkpoint checkpoints/diamond/breakout.pt \
+  --seeds 0,1 \
+  --episodes 5 \
+  --out-dir results/diamond_breakout
 ```
-python -m world_models.benchmarks.cli --all-agents --game ALE/Pong-v5 --seeds 1 --episodes 3
+
+Run DreamerV2 on a Gym environment:
+
+```bash
+torchwm benchmark \
+  --agent dreamerv2 \
+  --game Pong-v5 \
+  --checkpoint checkpoints/dreamerv2/pong.pt \
+  --seeds 1 \
+  --episodes 10 \
+  --device cpu
 ```
 
-Python API Example
-------------------
+Run all registered adapters on the same game with per-agent checkpoints:
 
-Use the `BenchmarkRunner` when you need programmatic control:
+```bash
+torchwm benchmark \
+  --all-agents \
+  --game ALE/Pong-v5 \
+  --checkpoint-map iris=checkpoints/iris/pong.pt \
+  --checkpoint-map diamond=checkpoints/diamond/pong.pt \
+  --checkpoint-map dreamerv1=checkpoints/dreamerv1/pong.pt \
+  --checkpoint-map dreamerv2=checkpoints/dreamerv2/pong.pt \
+  --seeds 0,1 \
+  --episodes 5 \
+  --out-dir results/pong_comparison
+```
+
+## CLI options
+
+Common `torchwm benchmark` options:
+
+- `--agent AGENT` / `-a AGENT`: run one adapter (`iris`, `diamond`, `dreamerv1`, or `dreamerv2`).
+- `--all-agents`: run every registered adapter on the same environment.
+- `--game GAME` / `-g GAME`: Gym/ALE environment id, such as `ALE/Pong-v5`.
+- `--checkpoint PATH` / `-c PATH`: checkpoint path for single-agent benchmarks.
+- `--checkpoint-map AGENT=PATH`: repeatable per-agent checkpoint mapping for `--all-agents`.
+- `--seeds SEEDS`: either `N` for seeds `0..N-1`, or a comma-separated list such as `0,1,2`.
+- `--episodes N` / `-n N`: number of evaluation episodes per seed.
+- `--out-dir DIR`: output directory for report artifacts. The legacy alias `--out_dir` is also accepted.
+- `--device DEVICE`: device forwarded to adapters. Defaults to CUDA when available, otherwise CPU.
+- `--preset PRESET`: optional adapter/model preset.
+- `--train-epochs N`: for `--all-agents`, train first when checkpoint maps are not supplied.
+
+You can also run `torchwm benchmark --help` to see the installed CLI help.
+
+## Module CLI compatibility
+
+The lower-level module entrypoint remains available for scripts that already use
+it:
+
+```bash
+python -m world_models.benchmarks.cli \
+  --agent iris \
+  --game ALE/Pong-v5 \
+  --checkpoint checkpoints/iris/pong.pt \
+  --seeds 1 \
+  --episodes 3
+```
+
+For new usage, prefer `torchwm benchmark` so benchmark runs are discoverable
+through the main TorchWM CLI alongside `torchwm train`, `torchwm envs`, and
+`torchwm datasets`.
+
+## Python API example
+
+Use `BenchmarkRunner` when you need programmatic control:
 
 ```py
 from world_models.benchmarks.runner import BenchmarkRunner
 from world_models.benchmarks import adapters
 
 runner = BenchmarkRunner(adapter_cls=adapters.IRISAdapter, out_dir="results/bench")
-res = runner.run(env_spec={"game": "ALE/Pong-v5"}, seeds=[0,1], num_episodes=5)
-print(res)
-```
-Python API Example
-------------------
-
-Use the `BenchmarkRunner` when you need programmatic control:
-
-```py
-from world_models.benchmarks.runner import BenchmarkRunner
-from world_models.benchmarks import adapters
-
-runner = BenchmarkRunner(adapter_cls=adapters.IRISAdapter, out_dir="results/bench")
-res = runner.run(env_spec={"game": "ALE/Pong-v5"}, seeds=[0,1], num_episodes=5)
+res = runner.run(
+    env_spec={"game": "ALE/Pong-v5"},
+    seeds=[0, 1],
+    num_episodes=5,
+    checkpoint="checkpoints/iris/pong.pt",
+)
 print(res)
 ```
 
-Running the Atari 100k Benchmark
----------------------------------
+## Running the Atari 100k benchmark
 
 To run the full Atari 100k benchmark on all 26 games using IRIS:
 
-```
+```bash
 python benchmarks/atari_100k.py
 ```
 
-This will train IRIS on each game for 100k environment steps with 5 random seeds per game, compute human-normalized scores, and compare to baselines.
+This trains IRIS on each game for 100k environment steps with 5 random seeds per
+game, computes human-normalized scores, and compares to baselines.
 
-Outputs
--------
-- The runner saves results into the `out_dir` (default `results/bench`):
-  - `benchmark_results.json` (raw structured results)
-  - `benchmark_results.csv` (seed rows)
-  - `benchmark_results.md` (human readable markdown table)
-  - `benchmark_results.tex` (LaTeX table ready for papers)
-Outputs
--------
-- The runner saves results into the `out_dir` (default `results/bench`):
-  - `benchmark_results.json` (raw structured results)
-  - `benchmark_results.csv` (seed rows)
-  - `benchmark_results.md` (human readable markdown table)
-  - `benchmark_results.tex` (LaTeX table ready for papers)
+## Outputs
 
-Computing IQM and bootstrap CIs
--------------------------------
+The runner saves these files into the selected `out_dir` (default
+`results/bench`):
 
-The runner stores per-seed means in the JSON under `aggregate.per_seed_means`. Use
-the provided metrics helpers to compute IQM and bootstrap confidence intervals:
+- `benchmark_results.json` - raw structured results.
+- `benchmark_results.csv` - per-seed rows.
+- `benchmark_results.md` - human-readable markdown table.
+- `benchmark_results.tex` - LaTeX table ready for papers.
+
+Multi-agent runs also write combined reports such as
+`combined_benchmark_results.json` and `combined_benchmark_results.csv` in the
+root output directory, with per-agent details under subdirectories.
+
+## Computing IQM and bootstrap CIs
+
+The runner stores per-seed means in the JSON under
+`aggregate.per_seed_means`. Use the provided metrics helpers to compute IQM and
+bootstrap confidence intervals:
 
 ```py
 from world_models.benchmarks import metrics, reporting
 import json
 
-res = json.load(open('results/bench/benchmark_results.json'))
-per_seed = res['aggregate']['per_seed_means']
+res = json.load(open("results/bench/benchmark_results.json"))
+per_seed = res["aggregate"]["per_seed_means"]
 iqm = metrics.iqm_of_array(per_seed)
 lower, upper = metrics.bootstrap_iqm_ci(per_seed, num_samples=2000, alpha=0.05)
 print(f"IQM={iqm:.3f} (95% CI {lower:.3f} - {upper:.3f})")
 
-# export LaTeX table from results
-reporting.export_latex(res, 'results/bench/benchmark_results.tex')
+reporting.export_latex(res, "results/bench/benchmark_results.tex")
 ```
 
-Extending the harness
----------------------
+## Extending the harness
+
 - Create an adapter in `world_models/benchmarks/adapters.py` that implements:
-  - `load_checkpoint(path: str)` and
-  - `evaluate(num_episodes: int, render: bool = False)` returning `{"episode_returns": List[float]}`.
-- Register your adapter in `world_models/benchmarks/cli.py` to expose it via the CLI.
+  - `load_checkpoint(path: str)`
+  - `evaluate(num_episodes: int, render: bool = False)` returning `{"episode_returns": list[float]}`
+- Register your adapter in `world_models/benchmarks/cli.py` to expose it through both `python -m world_models.benchmarks.cli` and `torchwm benchmark`.
 
-Tests and CI
------------
+## Tests and CI
+
 - Place smoke tests under `world_models/benchmarks/tests/` so CI can run them quickly.
-- The repo contains a `mocking_classes.py` helper for building fake agents/environments for fast unit tests.
+- The repo contains a `mocking_classes.py` helper for building fake agents and environments for fast unit tests.
 
-Where to start
---------------
-- Run the examples in `examples/benchmark_iris.py` or use the CLI directly.
-- If you need help wiring specific agent configs (device, preset, checkpoint paths), use the CLI `--device` and `--preset` flags or call the runner programmatically and pass `extra_kwargs`.
+## Where to start
+
+- Run the examples in `examples/benchmark_iris.py` or use `torchwm benchmark` directly.
+- If you need help wiring specific agent configs, use `--device`, `--preset`, and checkpoint options, or call the runner programmatically and pass `extra_kwargs`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "tqdm>=4.67.1",
     "opencv-python>=4.12.0.88",
     "requests>=2.32.0",
+    "typer>=0.12.0",
     "gym>=0.26.2",
     "gymnasium>=1.2.2",
     "moviepy>=2.2.1",

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         "einops>=0.8.2",
         "pyyaml>=6.0.3",
         "tqdm>=4.67.1",
+        "typer>=0.12.0",
     ],
     extras_require={
         "gym": [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,3 +39,84 @@ def test_train_unknown_model_errors():
     res = runner.invoke(cli.app, ["train", "notamodel"])
     assert res.exit_code == 1
     assert "Unknown model" in res.output
+
+
+def test_benchmark_requires_agent_or_all_agents():
+    runner = CliRunner()
+    res = runner.invoke(cli.app, ["benchmark", "--game", "ALE/Pong-v5"])
+    assert res.exit_code == 1
+    assert "Either --agent or --all-agents" in res.output
+
+
+def test_benchmark_single_agent_requires_checkpoint():
+    runner = CliRunner()
+    res = runner.invoke(
+        cli.app, ["benchmark", "--agent", "iris", "--game", "ALE/Pong-v5"]
+    )
+    assert res.exit_code == 1
+    assert "--checkpoint is required" in res.output
+
+
+def test_benchmark_single_agent_runs_with_checkpoint(monkeypatch, tmp_path):
+    calls = {}
+
+    class FakeBenchmarkRunner:
+        def __init__(self, adapter_cls, out_dir):
+            calls["adapter_cls"] = adapter_cls
+            calls["out_dir"] = out_dir
+
+        def run(self, **kwargs):
+            calls["run_kwargs"] = kwargs
+            return {"aggregate": {}}
+
+    class FakeMultiAgentBenchmarkRunner:
+        pass
+
+    class FakeCuda:
+        @staticmethod
+        def is_available():
+            return False
+
+    class FakeTorch:
+        cuda = FakeCuda()
+
+    monkeypatch.setattr(
+        cli,
+        "_load_benchmark_runtime",
+        lambda: (
+            {"iris": object},
+            FakeBenchmarkRunner,
+            FakeMultiAgentBenchmarkRunner,
+            FakeTorch,
+        ),
+    )
+
+    runner = CliRunner()
+    res = runner.invoke(
+        cli.app,
+        [
+            "benchmark",
+            "--agent",
+            "iris",
+            "--game",
+            "ALE/Pong-v5",
+            "--checkpoint",
+            str(tmp_path / "iris.pt"),
+            "--seeds",
+            "0,2",
+            "--episodes",
+            "3",
+            "--out-dir",
+            str(tmp_path / "bench"),
+            "--device",
+            "cpu",
+        ],
+    )
+    assert res.exit_code == 0
+    assert "Benchmark finished" in res.output
+    assert calls["out_dir"] == str(tmp_path / "bench")
+    assert calls["run_kwargs"]["env_spec"] == {"game": "ALE/Pong-v5"}
+    assert calls["run_kwargs"]["seeds"] == [0, 2]
+    assert calls["run_kwargs"]["num_episodes"] == 3
+    assert calls["run_kwargs"]["checkpoint"] == str(tmp_path / "iris.pt")
+    assert calls["run_kwargs"]["extra_kwargs"]["device"] == "cpu"

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -17,6 +17,7 @@ from .cli import (
     datasets_list,
     datasets_convert,
     collect,
+    benchmark,
     train,
 )
 
@@ -35,6 +36,7 @@ __all__ = [
     "datasets_list",
     "datasets_convert",
     "collect",
+    "benchmark",
     "train",
     "check_docs_main",
     "check_page",

--- a/tools/cli.py
+++ b/tools/cli.py
@@ -16,8 +16,6 @@ import subprocess
 import logging
 from pathlib import Path
 from typing import List
-from world_models.datasets.video_datasets import HDF5Dataset, NumPyDataset
-from world_models.utils.utils import save_video
 from typer.main import get_command as _typer_get_command
 import typer
 
@@ -75,6 +73,49 @@ TRAINING_MODULES = {
 }
 
 
+BENCHMARK_AGENT_NAMES = ("diamond", "iris", "dreamerv1", "dreamerv2")
+
+
+def _parse_benchmark_seeds(value: str) -> List[int]:
+    """Parse benchmark seed syntax shared with the benchmark module CLI."""
+    if "," in value:
+        return [int(item.strip()) for item in value.split(",") if item.strip()]
+    if value.isdigit():
+        return list(range(int(value)))
+    return [int(value)]
+
+
+def _load_benchmark_runtime():
+    """Lazy-load benchmark runtime classes after lightweight validation passes."""
+    from world_models.benchmarks.cli import AGENTS
+    from world_models.benchmarks.runner import (
+        BenchmarkRunner,
+        MultiAgentBenchmarkRunner,
+    )
+    import torch
+
+    return AGENTS, BenchmarkRunner, MultiAgentBenchmarkRunner, torch
+
+
+def _parse_checkpoint_map(values: List[str] | None) -> dict[str, str]:
+    """Parse repeated ``--checkpoint-map agent=path`` values."""
+    checkpoints: dict[str, str] = {}
+    for value in values or []:
+        if "=" not in value:
+            raise ValueError(
+                f"Invalid checkpoint map '{value}'. Expected AGENT=PATH, for example iris=checkpoints/iris.pt."
+            )
+        agent, path = value.split("=", 1)
+        agent = agent.strip().lower()
+        path = path.strip()
+        if not agent or not path:
+            raise ValueError(
+                f"Invalid checkpoint map '{value}'. Agent and path must both be non-empty."
+            )
+        checkpoints[agent] = path
+    return checkpoints
+
+
 def _ensure_gym():
     """Lazy-import `gym` (fall back to `gymnasium`) and cache result.
 
@@ -85,6 +126,7 @@ def _ensure_gym():
     except Exception:
         import gymnasium as _gym
     return _gym
+
 
 def _ensure_numpy():
     """Lazy-import numpy and cache result. Returns module or None."""
@@ -225,15 +267,14 @@ def datasets_convert(
         print("Only 'video' dest_format supported in this initial implementation.")
         raise typer.Exit(code=1)
 
-    # Ensure optional top-level imports succeeded
-    if (
-        HDF5Dataset is None
-        or NumPyDataset is None
-        or save_video is None
-        or _ensure_numpy() is None
-    ):
-        logger.exception("Missing dataset conversion dependencies")
-        print("Install the optional dependencies (h5py, numpy, etc.) and retry.")
+    # Import conversion dependencies only when this command is invoked so the
+    # rest of the CLI can start in lightweight environments.
+    from world_models.datasets.video_datasets import HDF5Dataset, NumPyDataset
+    from world_models.utils.utils import save_video
+
+    if _ensure_numpy() is None:
+        logger.exception("Missing numpy")
+        print("Install the optional dependencies (numpy, h5py, etc.) and retry.")
         raise typer.Exit(code=1)
 
     srcp = Path(src)
@@ -301,6 +342,155 @@ def datasets_convert(
         except Exception as e:
             logger.exception("Failed to convert item %d: %s", i, e)
             print(f"Failed to convert item {i}: {e}")
+
+
+@app.command("benchmark")
+def benchmark(
+    agent: str | None = typer.Option(
+        None,
+        "--agent",
+        "-a",
+        help="Agent adapter to evaluate (for example: iris, diamond, dreamerv1, dreamerv2).",
+    ),
+    all_agents: bool = typer.Option(
+        False,
+        "--all-agents",
+        help="Run all registered benchmark adapters on the same environment.",
+    ),
+    game: str = typer.Option(
+        ...,
+        "--game",
+        "-g",
+        help="Gym/ALE environment id to benchmark, such as ALE/Pong-v5.",
+    ),
+    seeds: str = typer.Option(
+        "1",
+        "--seeds",
+        help="Either N (creates seeds 0..N-1) or a comma-separated seed list.",
+    ),
+    episodes: int = typer.Option(
+        5, "--episodes", "-n", help="Evaluation episodes to run per seed."
+    ),
+    checkpoint: Path | None = typer.Option(
+        None,
+        "--checkpoint",
+        "-c",
+        help="Checkpoint path for a single-agent benchmark.",
+    ),
+    checkpoint_map: List[str] | None = typer.Option(
+        None,
+        "--checkpoint-map",
+        help="For --all-agents, repeat as AGENT=PATH (for example --checkpoint-map iris=ckpt.pt).",
+    ),
+    out_dir: Path = typer.Option(
+        Path("results/bench"),
+        "--out-dir",
+        "--out_dir",
+        help="Directory where JSON/CSV/Markdown/LaTeX benchmark reports are written.",
+    ),
+    device: str | None = typer.Option(
+        None,
+        "--device",
+        help="Device passed to adapters. Defaults to CUDA when available, otherwise CPU.",
+    ),
+    preset: str | None = typer.Option(
+        None,
+        "--preset",
+        help="Optional adapter/model preset to forward to benchmark adapters.",
+    ),
+    train_epochs: int | None = typer.Option(
+        None,
+        "--train-epochs",
+        help="For --all-agents only: train agents first for this many epochs if no checkpoints are supplied.",
+    ),
+) -> None:
+    """Run TorchWM benchmark evaluations and write report artifacts.
+
+    This is the packaged `torchwm` entrypoint for the benchmark harness that can
+    also be invoked with `python -m world_models.benchmarks.cli`. Benchmarking
+    trained agents requires checkpoints; `--train-epochs` is available for
+    multi-agent smoke runs that intentionally train before evaluating.
+    """
+    try:
+        if not all_agents and not agent:
+            print("Either --agent or --all-agents must be specified")
+            raise typer.Exit(code=1)
+
+        if all_agents and agent:
+            print("--agent and --all-agents cannot be used together")
+            raise typer.Exit(code=1)
+
+        if agent:
+            agent = agent.strip().lower()
+            if agent not in BENCHMARK_AGENT_NAMES:
+                print(
+                    f"Unknown benchmark agent '{agent}'. Known: {', '.join(sorted(BENCHMARK_AGENT_NAMES))}"
+                )
+                raise typer.Exit(code=1)
+            if checkpoint is None:
+                print(
+                    "--checkpoint is required when using --agent. Only trained models should be benchmarked."
+                )
+                raise typer.Exit(code=1)
+
+        seed_values = _parse_benchmark_seeds(seeds)
+        env_spec = {"game": game}
+
+        if all_agents:
+            checkpoints = _parse_checkpoint_map(checkpoint_map)
+            unknown_checkpoints = sorted(
+                set(checkpoints).difference(BENCHMARK_AGENT_NAMES)
+            )
+            if unknown_checkpoints:
+                print(
+                    f"Unknown benchmark checkpoint agent(s): {', '.join(unknown_checkpoints)}. Known: {', '.join(sorted(BENCHMARK_AGENT_NAMES))}"
+                )
+                raise typer.Exit(code=1)
+            if not checkpoints and train_epochs is None:
+                print(
+                    "Provide --checkpoint-map AGENT=PATH at least once, or provide --train-epochs for --all-agents."
+                )
+                raise typer.Exit(code=1)
+
+        AGENTS, BenchmarkRunner, MultiAgentBenchmarkRunner, torch = (
+            _load_benchmark_runtime()
+        )
+        if device is None:
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+        extra_kwargs = {"device": device, "preset": preset}
+
+        if all_agents:
+            runner = MultiAgentBenchmarkRunner(
+                adapters=list(AGENTS.values()), out_dir=str(out_dir)
+            )
+            runner.run_all(
+                env_spec=env_spec,
+                seeds=seed_values,
+                num_episodes=episodes,
+                checkpoints=checkpoints or None,
+                extra_kwargs=extra_kwargs,
+                train_epochs=train_epochs,
+            )
+            print(f"Multi-agent benchmark finished. Results written to: {out_dir}")
+            raise typer.Exit(code=0)
+
+        assert agent is not None
+        assert checkpoint is not None
+        runner = BenchmarkRunner(adapter_cls=AGENTS[agent], out_dir=str(out_dir))
+        runner.run(
+            env_spec=env_spec,
+            seeds=seed_values,
+            num_episodes=episodes,
+            checkpoint=str(checkpoint),
+            extra_kwargs=extra_kwargs,
+        )
+        print(f"Benchmark finished. Results written to: {out_dir}")
+    except ValueError as e:
+        print(str(e))
+        raise typer.Exit(code=1)
+    except KeyboardInterrupt:
+        print("Benchmark interrupted by user")
+        raise typer.Exit(code=1)
 
 
 @app.command("collect")
@@ -448,6 +638,7 @@ def train(
     except KeyboardInterrupt:
         print("Training interrupted by user")
         raise typer.Exit(code=1)
+
 
 if __name__ == "__main__":
     app()


### PR DESCRIPTION
### Motivation

- Provide a first-class `torchwm benchmark` entrypoint so users can run single-agent and multi-agent benchmarking from the main CLI instead of invoking the module directly. 
- Keep CLI startup lightweight by deferring heavy benchmark/training imports until the command runs, and document the new workflow in the docs.

### Description

- Add a new `benchmark` subcommand to the main CLI in `tools/cli.py` with options `--agent`, `--all-agents`, `--game`, `--seeds`, `--episodes`, `--checkpoint`, repeatable `--checkpoint-map`, `--out-dir`, `--device`, `--preset`, and `--train-epochs` that wraps `world_models.benchmarks.runner` for single- and multi-agent runs. 
- Implement helper utilities in `tools/cli.py` for seed parsing, checkpoint-map parsing, and lazy runtime loading of the benchmark classes so the normal CLI stays lightweight. 
- Move dataset-conversion imports to command-time lazy imports so `datasets convert` no longer forces heavy top-level imports. 
- Export the new `benchmark` command from `tools/__init__.py`, add `typer>=0.12.0` to packaging metadata (`pyproject.toml` and `setup.py`), update `docs/source/benchmarks.md` to prefer `torchwm benchmark` and include examples, and add CLI tests in `tests/test_cli.py` that exercise the new command paths (validation and a mocked successful single-agent run). 

### Testing

- Performed static parsing of modified files with `ast.parse(...)` which succeeded for `tools/cli.py`, `tests/test_cli.py`, `setup.py`, and `tools/__init__.py`. 
- Ran code formatting with `black` and `git diff --check` to validate style and no whitespace errors. 
- Added automated CLI tests in `tests/test_cli.py` that cover required/optional flags and a mocked successful run, but executing `python -m pytest tests/test_cli.py` in this environment failed because `typer` was not installed and network access for package installation was blocked (pip requests returned 403), so the new tests were not executed end-to-end here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c47b0c0bc832ebfccc74eae560bf8)