### PR TITLE
Add optional windowed-attention pooling for latent action tokens

### DIFF
--- a/tests/test_genie.py
+++ b/tests/test_genie.py
@@ -103,6 +103,31 @@ class TestLatentActionModel:
         assert latent_actions.shape == (B, T)
         assert z_q.shape[0] == B
 
+    def test_encode_with_windowed_attention_pooling(self):
+        lam = create_latent_action_model(
+            num_frames=8,
+            image_size=32,
+            encoder_dim=256,
+            encoder_depth=4,
+            num_heads=8,
+            vocab_size=8,
+            embedding_dim=32,
+            action_pooling="windowed_attention",
+            window_attention_heads=4,
+        )
+        lam.eval()
+
+        B, C, T, H, W = 2, 3, 8, 32, 32
+        x_prev = torch.randn(B, C, T, H, W)
+        x_next = torch.randn(B, C, H, W)
+
+        with torch.no_grad():
+            latent_actions, z_q = lam.encode(x_prev, x_next)
+
+        assert lam.action_pooling == "windowed_attention"
+        assert latent_actions.shape == (B, T)
+        assert z_q.shape == (B, T, 32)
+
 
 class TestGenie:
     def test_initialization(self):

--- a/world_models/configs/genie_config.py
+++ b/world_models/configs/genie_config.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Literal
 
 
 @dataclass
@@ -22,6 +23,8 @@ class GenieConfig:
     action_encoder_dim: int = 256
     action_encoder_depth: int = 4
     action_num_heads: int = 8
+    action_pooling: Literal["mean", "windowed_attention"] = "mean"
+    window_attention_heads: int = 1
 
     dynamics_dim: int = 512
     dynamics_depth: int = 8
@@ -61,6 +64,8 @@ class GenieSmallConfig:
     action_encoder_dim: int = 512
     action_encoder_depth: int = 8
     action_num_heads: int = 8
+    action_pooling: Literal["mean", "windowed_attention"] = "mean"
+    window_attention_heads: int = 1
 
     dynamics_dim: int = 512
     dynamics_depth: int = 8
@@ -126,6 +131,8 @@ class LatentActionModelConfig:
     vocab_size: int = 8
     embedding_dim: int = 32
     commitment_weight: float = 1.0
+    action_pooling: Literal["mean", "windowed_attention"] = "mean"
+    window_attention_heads: int = 1
 
 
 @dataclass

--- a/world_models/models/genie.py
+++ b/world_models/models/genie.py
@@ -1,7 +1,7 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from typing import Optional, Tuple, Dict
+from typing import Optional, Tuple, Dict, Literal
 
 from world_models.vision.video_tokenizer import VideoTokenizer
 from world_models.models.latent_action_model import LatentActionModel
@@ -51,6 +51,8 @@ class Genie(nn.Module):
         decoder_depth: int = 20,
         latent_action_depth: int = 20,
         use_bfloat16: bool = False,
+        action_pooling: Literal["mean", "windowed_attention"] = "mean",
+        window_attention_heads: int = 1,
     ):
         super().__init__()
         self.num_frames = num_frames
@@ -89,6 +91,8 @@ class Genie(nn.Module):
             vocab_size=action_vocab_size,
             embedding_dim=action_embedding_dim,
             commitment_weight=1.0,
+            action_pooling=action_pooling,
+            window_attention_heads=window_attention_heads,
         )
 
         # Dynamics Model (MaskGIT transformer)
@@ -437,6 +441,8 @@ def create_genie(
     dynamics_depth: int = 48,
     dynamics_num_heads: int = 36,
     use_bfloat16: bool = False,
+    action_pooling: Literal["mean", "windowed_attention"] = "mean",
+    window_attention_heads: int = 1,
 ) -> Genie:
     """Factory function to create a Genie model."""
     return Genie(
@@ -451,6 +457,8 @@ def create_genie(
         dynamics_depth=dynamics_depth,
         dynamics_num_heads=dynamics_num_heads,
         use_bfloat16=use_bfloat16,
+        action_pooling=action_pooling,
+        window_attention_heads=window_attention_heads,
     )
 
 
@@ -458,6 +466,8 @@ def create_genie_small(
     num_frames: int = 16,
     image_size: int = 64,
     use_bfloat16: bool = False,
+    action_pooling: Literal["mean", "windowed_attention"] = "mean",
+    window_attention_heads: int = 1,
 ) -> Genie:
     """Create a smaller Genie model for development/testing."""
     return Genie(
@@ -478,6 +488,8 @@ def create_genie_small(
         decoder_depth=8,
         latent_action_depth=8,
         use_bfloat16=use_bfloat16,
+        action_pooling=action_pooling,
+        window_attention_heads=window_attention_heads,
     )
 
 
@@ -485,6 +497,8 @@ def create_genie_large(
     num_frames: int = 16,
     image_size: int = 64,
     use_bfloat16: bool = True,
+    action_pooling: Literal["mean", "windowed_attention"] = "mean",
+    window_attention_heads: int = 1,
 ) -> Genie:
     """Create the full 11B parameter Genie model (approximate)."""
     return Genie(
@@ -505,4 +519,6 @@ def create_genie_large(
         decoder_depth=20,
         latent_action_depth=20,
         use_bfloat16=use_bfloat16,
+        action_pooling=action_pooling,
+        window_attention_heads=window_attention_heads,
     )

--- a/world_models/models/latent_action_model.py
+++ b/world_models/models/latent_action_model.py
@@ -43,12 +43,13 @@ class LatentActionModel(nn.Module):
             raise ValueError(
                 "action_pooling must be either 'mean' or 'windowed_attention'"
             )
-        if window_attention_heads < 1:
-            raise ValueError("window_attention_heads must be at least 1")
-        if embedding_dim % window_attention_heads != 0:
-            raise ValueError(
-                "embedding_dim must be divisible by window_attention_heads"
-            )
+        if action_pooling == "windowed_attention":
+            if window_attention_heads < 1:
+                raise ValueError("window_attention_heads must be at least 1")
+            if embedding_dim % window_attention_heads != 0:
+                raise ValueError(
+                    "embedding_dim must be divisible by window_attention_heads"
+                )
         self.num_frames = num_frames
         self.image_size = image_size
         self.patch_size = patch_size
@@ -166,36 +167,32 @@ class LatentActionModel(nn.Module):
         nn.init.xavier_uniform_(self.decoder_out.weight)
         nn.init.zeros_(self.decoder_out.bias)
 
-    def _pool_action_tokens(self, x_embed: torch.Tensor) -> torch.Tensor:
-        """Pool per-frame action tokens before vector quantization.
+    def _pool_windowed_attention(
+        self, x_t_embed: torch.Tensor, x_next_embed: torch.Tensor
+    ) -> torch.Tensor:
+        """Apply length-2 temporal attention, then mean-pool the attended tokens.
 
         Args:
-            x_embed: Encoder embeddings with shape (B, T, N, embedding_dim), where
-                N is the number of spatial patches.
+            x_t_embed: Current timestep embeddings with shape (B, N, embedding_dim).
+            x_next_embed: Next timestep embeddings with shape (B, N, embedding_dim).
 
         Returns:
-            Pooled action embeddings with shape (B, T, embedding_dim).
+            Pooled action embeddings with shape (B, embedding_dim).
         """
-        if self.action_pooling == "mean":
-            return x_embed.mean(dim=2)
-
         if self.window_attention is None:
             raise RuntimeError("window attention module is not initialized")
 
-        B, T, N, E = x_embed.shape
-        # Build length-2 temporal windows for every spatial patch, using the
-        # current frame token and the next frame token (repeat the final frame).
-        next_tokens = torch.cat([x_embed[:, 1:], x_embed[:, -1:].clone()], dim=1)
-        windows = torch.stack([x_embed, next_tokens], dim=3)
-        windows = windows.reshape(B * T * N, 2, E)
+        B, N, E = x_t_embed.shape
+        windows = torch.stack([x_t_embed, x_next_embed], dim=2)
+        windows = windows.reshape(B * N, 2, E)
         attended_windows, _ = self.window_attention(
             windows,
             windows,
             windows,
             need_weights=False,
         )
-        attended_windows = attended_windows.reshape(B, T, N, 2, E)
-        return attended_windows.mean(dim=(2, 3))
+        attended_windows = attended_windows.reshape(B, N, 2, E)
+        return attended_windows.mean(dim=(1, 2))
 
     def encode(
         self, x_prev: torch.Tensor, x_next: torch.Tensor
@@ -235,16 +232,28 @@ class LatentActionModel(nn.Module):
         x = x.reshape(B, T + 1, num_patches, C_enc)
         x = x[:, :T, :, :]  # (B, T, N, C)
 
-        # Project to VQ embedding space, optionally apply local temporal attention,
-        # then pool each timestep to one action embedding.
-        x_embed = self.to_vq_embedding(x)  # (B, T, N, embedding_dim)
-        x_pooled = self._pool_action_tokens(x_embed)  # (B, T, embedding_dim)
-
-        # Quantize each timestep.
+        # Quantize each timestep
         z_all = []
         indices_all = []
         for t in range(T):
-            z_q_t, indices_t, _ = self.vq(x_pooled[:, t, :])
+            x_t = x[:, t, :, :]  # (B, N, C)
+
+            x_t_embed = self.to_vq_embedding(x_t)  # (B, N, embedding_dim)
+
+            if self.action_pooling == "windowed_attention":
+                next_t = min(t + 1, T - 1)
+                x_next_t = x[:, next_t, :, :]  # (B, N, C)
+                x_next_t_embed = self.to_vq_embedding(
+                    x_next_t
+                )  # (B, N, embedding_dim)
+                x_t_pooled = self._pool_windowed_attention(
+                    x_t_embed, x_next_t_embed
+                )  # (B, embedding_dim)
+            else:
+                # Pool across spatial dimension
+                x_t_pooled = x_t_embed.mean(dim=1)  # (B, embedding_dim)
+
+            z_q_t, indices_t, _ = self.vq(x_t_pooled)
             z_all.append(z_q_t)
             indices_all.append(indices_t)
 

--- a/world_models/models/latent_action_model.py
+++ b/world_models/models/latent_action_model.py
@@ -1,7 +1,7 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from typing import Tuple, Optional, Dict
+from typing import Tuple, Optional, Dict, Literal
 
 from world_models.vision.vq_layer import VectorQuantizer
 from world_models.blocks.st_transformer import STTransformer
@@ -35,8 +35,20 @@ class LatentActionModel(nn.Module):
         vocab_size: int = 8,
         embedding_dim: int = 32,
         commitment_weight: float = 1.0,
+        action_pooling: Literal["mean", "windowed_attention"] = "mean",
+        window_attention_heads: int = 1,
     ):
         super().__init__()
+        if action_pooling not in {"mean", "windowed_attention"}:
+            raise ValueError(
+                "action_pooling must be either 'mean' or 'windowed_attention'"
+            )
+        if window_attention_heads < 1:
+            raise ValueError("window_attention_heads must be at least 1")
+        if embedding_dim % window_attention_heads != 0:
+            raise ValueError(
+                "embedding_dim must be divisible by window_attention_heads"
+            )
         self.num_frames = num_frames
         self.image_size = image_size
         self.patch_size = patch_size
@@ -45,6 +57,7 @@ class LatentActionModel(nn.Module):
         self.decoder_dim = decoder_dim
         self.embedding_dim = embedding_dim
         self.in_channels = in_channels
+        self.action_pooling = action_pooling
 
         num_patches = (image_size // patch_size) ** 2
 
@@ -79,6 +92,15 @@ class LatentActionModel(nn.Module):
         )
 
         self.to_vq_embedding = nn.Linear(encoder_dim, embedding_dim)
+        self.window_attention = (
+            nn.MultiheadAttention(
+                embed_dim=embedding_dim,
+                num_heads=window_attention_heads,
+                batch_first=True,
+            )
+            if action_pooling == "windowed_attention"
+            else None
+        )
 
         self.vq = VectorQuantizer(
             vocab_size=vocab_size,
@@ -144,6 +166,37 @@ class LatentActionModel(nn.Module):
         nn.init.xavier_uniform_(self.decoder_out.weight)
         nn.init.zeros_(self.decoder_out.bias)
 
+    def _pool_action_tokens(self, x_embed: torch.Tensor) -> torch.Tensor:
+        """Pool per-frame action tokens before vector quantization.
+
+        Args:
+            x_embed: Encoder embeddings with shape (B, T, N, embedding_dim), where
+                N is the number of spatial patches.
+
+        Returns:
+            Pooled action embeddings with shape (B, T, embedding_dim).
+        """
+        if self.action_pooling == "mean":
+            return x_embed.mean(dim=2)
+
+        if self.window_attention is None:
+            raise RuntimeError("window attention module is not initialized")
+
+        B, T, N, E = x_embed.shape
+        # Build length-2 temporal windows for every spatial patch, using the
+        # current frame token and the next frame token (repeat the final frame).
+        next_tokens = torch.cat([x_embed[:, 1:], x_embed[:, -1:].clone()], dim=1)
+        windows = torch.stack([x_embed, next_tokens], dim=3)
+        windows = windows.reshape(B * T * N, 2, E)
+        attended_windows, _ = self.window_attention(
+            windows,
+            windows,
+            windows,
+            need_weights=False,
+        )
+        attended_windows = attended_windows.reshape(B, T, N, 2, E)
+        return attended_windows.mean(dim=(2, 3))
+
     def encode(
         self, x_prev: torch.Tensor, x_next: torch.Tensor
     ) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -182,18 +235,16 @@ class LatentActionModel(nn.Module):
         x = x.reshape(B, T + 1, num_patches, C_enc)
         x = x[:, :T, :, :]  # (B, T, N, C)
 
-        # Quantize each timestep
+        # Project to VQ embedding space, optionally apply local temporal attention,
+        # then pool each timestep to one action embedding.
+        x_embed = self.to_vq_embedding(x)  # (B, T, N, embedding_dim)
+        x_pooled = self._pool_action_tokens(x_embed)  # (B, T, embedding_dim)
+
+        # Quantize each timestep.
         z_all = []
         indices_all = []
         for t in range(T):
-            x_t = x[:, t, :, :]  # (B, N, C)
-
-            x_t_embed = self.to_vq_embedding(x_t)  # (B, N, embedding_dim)
-
-            # Pool across spatial dimension
-            x_t_pooled = x_t_embed.mean(dim=1)  # (B, embedding_dim)
-
-            z_q_t, indices_t, _ = self.vq(x_t_pooled)
+            z_q_t, indices_t, _ = self.vq(x_pooled[:, t, :])
             z_all.append(z_q_t)
             indices_all.append(indices_t)
 
@@ -339,6 +390,8 @@ def create_latent_action_model(
     patch_size: int = 16,
     vocab_size: int = 8,
     embedding_dim: int = 32,
+    action_pooling: Literal["mean", "windowed_attention"] = "mean",
+    window_attention_heads: int = 1,
 ) -> LatentActionModel:
     """Factory function to create a Latent Action Model."""
     return LatentActionModel(
@@ -353,4 +406,6 @@ def create_latent_action_model(
         patch_size=patch_size,
         vocab_size=vocab_size,
         embedding_dim=embedding_dim,
+        action_pooling=action_pooling,
+        window_attention_heads=window_attention_heads,
     )

--- a/world_models/training/train_genie.py
+++ b/world_models/training/train_genie.py
@@ -1,7 +1,7 @@
 import torch
 import torch.nn as nn
 from torch.utils.data import Dataset, DataLoader
-from typing import Optional, Dict, Tuple
+from typing import Optional, Dict, Tuple, Literal
 import numpy as np
 from dataclasses import dataclass
 from world_models.models.genie import Genie
@@ -26,6 +26,8 @@ class GenieConfig:
     action_embedding_dim: int = 32
     action_encoder_dim: int = 1024
     action_encoder_depth: int = 20
+    action_pooling: Literal["mean", "windowed_attention"] = "mean"
+    window_attention_heads: int = 1
 
     dynamics_dim: int = 512
     dynamics_depth: int = 8
@@ -282,6 +284,8 @@ def create_genie_trainer(
         encoder_depth=config.tokenizer_encoder_depth,
         decoder_depth=config.tokenizer_decoder_depth,
         latent_action_depth=config.action_encoder_depth,
+        action_pooling=config.action_pooling,
+        window_attention_heads=config.window_attention_heads,
     )
 
     trainer = GenieTrainer(model, config, device)


### PR DESCRIPTION
### Motivation
- Improve temporal modeling of per-frame action tokens by providing an alternative to the current spatial `mean` pooling with a short local (length-2) windowed attention mechanism. 
- Make the new pooling an opt-in configuration so training/inference can choose between `mean` pooling and `windowed_attention` without breaking existing defaults.

### Description
- Added `action_pooling` and `window_attention_heads` parameters to `LatentActionModel` and validated inputs, with `action_pooling` defaulting to `"mean"` and `window_attention_heads` defaulting to `1`.
- Implemented a `_pool_action_tokens` helper that either returns `x_embed.mean(dim=2)` for `mean` pooling or builds length-2 temporal windows and applies a `nn.MultiheadAttention` over each window followed by mean pooling for `windowed_attention`.
- Initialized an optional `window_attention` `nn.MultiheadAttention` module in `LatentActionModel` and applied the chosen pooling before VQ quantization in `encode` (replacing the prior simple spatial mean call path).
- Threaded the new options through the factory and higher-level code by updating `create_latent_action_model`, `Genie` constructor/factories, `Genie` configs (`world_models/configs/genie_config.py`), and the trainer factory (`create_genie_trainer`) so pooling can be selected from config; added a unit test covering the `windowed_attention` path in `tests/test_genie.py`.

### Testing
- Ran Python syntax/compile checks with `python -m py_compile world_models/models/latent_action_model.py world_models/models/genie.py world_models/configs/genie_config.py world_models/training/train_genie.py`, which succeeded. 
- Attempted to run the unit test `pytest -q tests/test_genie.py::TestLatentActionModel`, which failed to run due to the test environment missing the `torch` dependency (`ModuleNotFoundError: No module named 'torch'`).
- Attempted package-managed test execution with `uv run pytest -q tests/test_genie.py::TestLatentActionModel`, which failed due to network/tunnel errors when fetching dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21210fa65c832797622be338e58871)