### PR TITLE
Fix CI triggers and remove CUDA torch index pin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,6 @@ permissions:
 on:
   pull_request:
   push:
-    paths:
-      - 'tests/**'
 
 jobs:
   test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,14 +89,6 @@ docs = [
     "nbsphinx>=0.9.8",
 ]
 
-[tool.uv]
-index-url = "https://download.pytorch.org/whl/cu121"
-extra-index-url = ["https://pypi.org/simple"]
-index-strategy = "unsafe-best-match"
-
-[[tool.uv.index]]
-url = "https://download.pytorch.org/whl/cu121"
-default = true
 
 [build-system]
 requires = ["setuptools>=61.0", "wheel", "build"]


### PR DESCRIPTION
### Motivation
- CI was only triggered for `tests/**` changes which caused changes to `world_models/` or packaging to skip tests. 
- The editable install in CI could re-pull a CUDA-indexed `torch` after the workflow installed CPU wheels, causing conflicting installs. 
- `main.py` at the repo root was an empty file and served no purpose.

### Description
- Removed the empty root-level `main.py` file. 
- Removed the `push` `paths` filter from `.github/workflows/test.yml` so the Pytest workflow runs on all pushes. 
- Removed the `[tool.uv]` CUDA 12.1 index configuration from `pyproject.toml` so `pip install -e .` will not pin the CUDA torch index.

### Testing
- Parsed `pyproject.toml` with `tomllib` successfully using `python - <<'PY' ... tomllib.load(...) ... PY`. 
- Verified the workflow filter was removed with a small Python assertion reading `.github/workflows/test.yml` which succeeded. 
- Ran `git diff --check` which reported no whitespace errors. 
- Ran `pytest tests/ --tb=short`, which failed during collection due to missing runtime test dependencies in the local environment (notably `torch`, `gym`/`gymnasium`, and `selenium`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a242f3ed89483278f20812f3a9217bf)