### PR TITLE
Docker: configurable PyTorch wheel index, CLI entrypoint, and docs update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,43 @@
-FROM python:3.13-slim
+# syntax=docker/dockerfile:1
+ARG PYTHON_VERSION=3.11
+FROM python:${PYTHON_VERSION}-slim
+
+ARG PYTORCH_INDEX_URL=https://download.pytorch.org/whl/cpu
+ARG TORCHWM_EXTRAS=
 
 ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
     PIP_NO_CACHE_DIR=1 \
-    CUDA_VISIBLE_DEVICES=0
+    TORCHWM_HOME=/data/torchwm
 
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
-    curl \
     git \
-    wget \
+    ffmpeg \
+    libgl1 \
+    libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
-COPY pyproject.toml setup.py ./
+COPY pyproject.toml setup.py README.md ./
+COPY torchwm.pyi ./
+COPY torchwm ./torchwm
+COPY tools ./tools
 COPY world_models ./world_models
-COPY torchwm_ui ./torchwm_ui
 
-RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir -e .
+RUN python -m pip install --upgrade pip setuptools wheel && \
+    python -m pip install --index-url "${PYTORCH_INDEX_URL}" torch torchvision torchaudio && \
+    if [ -n "${TORCHWM_EXTRAS}" ]; then \
+        python -m pip install --editable ".[${TORCHWM_EXTRAS}]"; \
+    else \
+        python -m pip install --editable .; \
+    fi && \
+    torchwm version && \
+    mkdir -p "${TORCHWM_HOME}"
 
-RUN cd torchwm_ui && npm install
+VOLUME ["/data/torchwm"]
 
-EXPOSE 8000
-
-CMD ["uvicorn", "world_models.ui.server:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+ENTRYPOINT ["torchwm"]
+CMD ["--help"]

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -66,15 +66,35 @@ pip install torch torchvision torchaudio --index-url https://download.pytorch.or
 
 ## Docker
 
-Build and run using Docker:
+Build the default CPU image and run the TorchWM CLI:
 
 ```bash
 # Build
 docker build -t torchwm .
 
-# Run
-docker run -it torchwm
+# Show the CLI help
+docker run --rm torchwm
+
+# Run a specific command
+docker run --rm torchwm models list
 ```
+
+The Dockerfile installs PyTorch explicitly before installing TorchWM so the wheel
+source is controlled by the `PYTORCH_INDEX_URL` build argument. The default uses
+CPU wheels. To build against a CUDA wheel index, pass the matching PyTorch index
+and run the container with the NVIDIA runtime:
+
+```bash
+docker build \
+  --build-arg PYTORCH_INDEX_URL=https://download.pytorch.org/whl/cu121 \
+  -t torchwm:cu121 .
+
+docker run --rm --gpus all torchwm:cu121 models list
+```
+
+Additional optional dependency groups can be installed at build time with
+`TORCHWM_EXTRAS`, for example `--build-arg TORCHWM_EXTRAS=viz,ml`. Runtime data is
+stored under `/data/torchwm`, which you can persist with a bind mount or volume.
 
 ## Verification
 


### PR DESCRIPTION
### Motivation

- Allow control over which PyTorch wheel index and Python version are used when building the image (CPU vs CUDA, Python versions). 
- Simplify the container to provide the `torchwm` CLI as the primary entrypoint instead of building/running a separate web UI. 
- Persist runtime data and support optional dependency groups at build time.

### Description

- Introduced build arguments `PYTHON_VERSION`, `PYTORCH_INDEX_URL`, and `TORCHWM_EXTRAS` and switched the base image to `python:${PYTHON_VERSION}-slim` while adding Dockerfile syntax line. 
- Install additional system libraries (`ffmpeg`, `libgl1`, `libglib2.0-0`) and removed the UI/npm build steps. 
- Copy package sources (`torchwm`, `tools`, `world_models`) and metadata into the image and install `torch`, `torchvision`, and `torchaudio` from the configured `PYTORCH_INDEX_URL` before installing `torchwm` editable, optionally with extras via `TORCHWM_EXTRAS`. 
- Set `TORCHWM_HOME` and expose `/data/torchwm` as a volume, add `ENTRYPOINT ["torchwm"]` and default `CMD ["--help"]` to make the container CLI-focused. 
- Updated documentation (`docs/source/installation.md`) with new Docker build/run instructions, examples for building against CUDA wheels, and notes about `TORCHWM_EXTRAS` and runtime data persistence.

### Testing

- No automated tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a242f49802083278fdf793daa1449c7)