### PR TITLE
Expose DIAMOND & DiT in public API, make JAX optional, add smoke tests and coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,10 @@
+[run]
+branch = True
+source = world_models, torchwm, tools
+
+[report]
+show_missing = True
+skip_covered = False
+exclude_lines =
+    pragma: no cover
+    if __name__ == .__main__.:

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,5 @@ checkpoints/
 server.log
 .mypy_cache/
 .coverage
-.coveragerc
 coverage_report.json
 htmlcov/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
     "umap-learn>=0.5.11",
     "huggingface-hub>=1.14.0",
     "playwright>=1.60.0",
-    "jax>=0.10.1",
 ]
 
 [project.urls]
@@ -64,6 +63,7 @@ robotics = [
 ]
 brax = [
     "brax>=0.13.0",
+    "jax>=0.10.1",
 ]
 procgen = [
     "procgen>=0.10.7",

--- a/tests/envs/test_envs.py
+++ b/tests/envs/test_envs.py
@@ -1,86 +1,101 @@
-import pytest
+from types import ModuleType, SimpleNamespace
+
+import numpy as np
 
 from world_models.envs.dmc import DeepMindControlEnv
 
-pytestmark = [pytest.mark.integration, pytest.mark.slow]
+
+class _FakePhysics:
+    def render(self, height, width, camera_id=0):
+        assert camera_id in (0, 2)
+        return np.zeros((height, width, 3), dtype=np.uint8)
 
 
-@pytest.mark.skip(reason="Requires MuJoCo/EGL which is not available")
-class TestDeepMindControlEnv:
-    def test_env_creation(self):
-        env = DeepMindControlEnv(name="cartpole-swingup", seed=42, size=(64, 64))
-        assert env.observation_space is not None
-        assert env.action_space is not None
+class _FakeTimeStep:
+    def __init__(self, observation, reward=1.0, discount=0.99, last=False):
+        self.observation = observation
+        self.reward = reward
+        self.discount = discount
+        self._last = last
 
-    def test_env_step_and_reset(self):
-        env = DeepMindControlEnv(name="cartpole-swingup", seed=42, size=(64, 64))
-        obs = env.reset()
-        assert "image" in obs
-        action = env.action_space.sample()
-        next_obs, reward, done, info = env.step(action)
-        assert "image" in next_obs
-        assert isinstance(reward, float)
-        assert isinstance(done, bool)
-        assert "discount" in info
-
-    def test_env_render(self):
-        env = DeepMindControlEnv(name="cartpole-swingup", seed=42, size=(64, 64))
-        env.reset()
-        frame = env.render()
-        assert frame.shape == (64, 64, 3)
-        env.close()
-
-    def test_env_seed_reproducibility(self):
-        env1 = DeepMindControlEnv(name="cartpole-swingup", seed=42, size=(64, 64))
-        env2 = DeepMindControlEnv(name="cartpole-swingup", seed=42, size=(64, 64))
-        obs1 = env1.reset()
-        obs2 = env2.reset()
-        assert (obs1["image"] == obs2["image"]).all()
-        action = env1.action_space.sample()
-        next_obs1, _, _, _ = env1.step(action)
-        next_obs2, _, _, _ = env2.step(action)
-        assert (next_obs1["image"] == next_obs2["image"]).all()
-
-    def test_invalid_env_name(self):
-        try:
-            DeepMindControlEnv(name="invalid-env", seed=42, size=(64, 64))
-        except Exception as e:
-            assert isinstance(e, ValueError)
-
-    def test_different_image_sizes(self):
-        sizes = [(32, 32), (64, 64), (128, 128)]
-        for size in sizes:
-            env = DeepMindControlEnv(name="cartpole-swingup", seed=42, size=size)
-            obs = env.reset()
-            assert obs["image"].shape == (size[0], size[1], 3)
-
-    def test_multiple_resets(self):
-        env = DeepMindControlEnv(name="cartpole-swingup", seed=42, size=(64, 64))
-        for _ in range(5):
-            obs = env.reset()
-            assert "image" in obs
-
-    def test_step_after_done(self):
-        env = DeepMindControlEnv(name="cartpole-swingup", seed=42, size=(64, 64))
-        obs = env.reset()
-        done = False
-        while not done:
-            action = env.action_space.sample()
-            obs, reward, done, info = env.step(action)
-        try:
-            env.step(env.action_space.sample())
-        except Exception as e:
-            assert isinstance(e, RuntimeError)
-
-    def test_close_env(self):
-        env = DeepMindControlEnv(name="cartpole-swingup", seed=42, size=(64, 64))
-        env.reset()
-        env.close()
-        try:
-            env.step(env.action_space.sample())
-        except Exception as e:
-            assert isinstance(e, RuntimeError)
+    def last(self):
+        return self._last
 
 
-class TestMujocoEnv:
-    pass
+class _FakeDMCEnv:
+    def __init__(self):
+        self.physics = _FakePhysics()
+        self.step_calls = 0
+
+    def observation_spec(self):
+        return {"position": SimpleNamespace(shape=(2,))}
+
+    def action_spec(self):
+        return SimpleNamespace(
+            minimum=np.array([-1.0, -1.0], dtype=np.float32),
+            maximum=np.array([1.0, 1.0], dtype=np.float32),
+        )
+
+    def reset(self):
+        return _FakeTimeStep({"position": np.array([0.0, 0.5], dtype=np.float32)})
+
+    def step(self, action):
+        self.step_calls += 1
+        return _FakeTimeStep(
+            {"position": np.asarray(action, dtype=np.float32)},
+            reward=None,
+            discount=1.0,
+            last=self.step_calls >= 2,
+        )
+
+
+def _install_fake_dm_control(monkeypatch):
+    fake_env = _FakeDMCEnv()
+    suite = SimpleNamespace(load=lambda domain, task, task_kwargs: fake_env)
+    dm_control = ModuleType("dm_control")
+    dm_control.suite = suite
+    monkeypatch.setitem(__import__("sys").modules, "dm_control", dm_control)
+    return fake_env
+
+
+def test_deepmind_control_env_smoke_with_fake_suite(monkeypatch):
+    fake_env = _install_fake_dm_control(monkeypatch)
+
+    env = DeepMindControlEnv(name="cartpole-swingup", seed=42, size=(16, 24))
+
+    assert env.observation_space["image"].shape == (3, 16, 24)
+    assert env.action_space.shape == (2,)
+
+    obs = env.reset()
+    assert obs["image"].shape == (3, 16, 24)
+    assert obs["position"].shape == (2,)
+
+    next_obs, reward, done, info = env.step(np.array([0.25, -0.25], dtype=np.float32))
+    assert next_obs["image"].shape == (3, 16, 24)
+    assert reward == 0
+    assert done is False
+    assert info["discount"].dtype == np.float32
+    assert fake_env.step_calls == 1
+
+
+def test_deepmind_control_env_domain_alias_and_render_validation(monkeypatch):
+    calls = []
+    fake_env = _FakeDMCEnv()
+
+    def load(domain, task, task_kwargs):
+        calls.append((domain, task, task_kwargs))
+        return fake_env
+
+    dm_control = ModuleType("dm_control")
+    dm_control.suite = SimpleNamespace(load=load)
+    monkeypatch.setitem(__import__("sys").modules, "dm_control", dm_control)
+
+    env = DeepMindControlEnv(name="cup-catch", seed=7, size=(8, 8))
+    assert calls == [("ball_in_cup", "catch", {"random": 7})]
+
+    try:
+        env.render(mode="human")
+    except ValueError as exc:
+        assert "rgb_array" in str(exc)
+    else:
+        raise AssertionError("DeepMindControlEnv.render should reject non-RGB modes")

--- a/tests/masks/test_masks.py
+++ b/tests/masks/test_masks.py
@@ -1,0 +1,44 @@
+import torch
+
+from world_models.masks import DefaultCollator, MultiblockMaskCollator, RandomMaskCollator
+
+
+def test_default_collator_returns_batch_without_masks():
+    batch, masks_enc, masks_pred = DefaultCollator()([torch.tensor([1]), torch.tensor([2])])
+
+    assert batch.shape == (2, 1)
+    assert masks_enc is None
+    assert masks_pred is None
+
+
+def test_random_mask_collator_splits_patch_indices():
+    collator = RandomMaskCollator(ratio=(0.5, 0.5), input_size=(8, 8), patch_size=4)
+
+    batch, masks_enc, masks_pred = collator([torch.zeros(1), torch.ones(1)])
+
+    assert batch.shape == (2, 1)
+    assert masks_enc.shape == (2, 2)
+    assert masks_pred.shape == (2, 2)
+    assert torch.cat([masks_enc[0], masks_pred[0]]).sort().values.tolist() == [0, 1, 2, 3]
+
+
+def test_multiblock_mask_collator_returns_batched_masks():
+    collator = MultiblockMaskCollator(
+        input_size=(16, 16),
+        patch_size=4,
+        enc_mask_scale=(0.5, 0.5),
+        pred_mask_scale=(0.5, 0.5),
+        aspect_ratio=(1.0, 1.0),
+        nenc=1,
+        npred=1,
+        min_keep=1,
+        allow_overlap=True,
+    )
+
+    batch, masks_enc, masks_pred = collator([torch.zeros(1), torch.ones(1)])
+
+    assert batch.shape == (2, 1)
+    assert masks_enc.shape[0:2] == (2, 1)
+    assert masks_pred.shape[0:2] == (2, 1)
+    assert masks_enc.numel() > 0
+    assert masks_pred.numel() > 0

--- a/tests/masks/test_masks.py
+++ b/tests/masks/test_masks.py
@@ -3,8 +3,23 @@ import torch
 from world_models.masks import DefaultCollator, MultiblockMaskCollator, RandomMaskCollator
 
 
+def _assert_mask_collection(mask_collection, batch_size, num_masks):
+    if isinstance(mask_collection, torch.Tensor):
+        assert mask_collection.shape[0:2] == (batch_size, num_masks)
+        assert mask_collection.numel() > 0
+        return
+
+    assert isinstance(mask_collection, list)
+    assert len(mask_collection) == num_masks
+    for mask in mask_collection:
+        assert mask.shape[0] == batch_size
+        assert mask.numel() > 0
+
+
 def test_default_collator_returns_batch_without_masks():
-    batch, masks_enc, masks_pred = DefaultCollator()([torch.tensor([1]), torch.tensor([2])])
+    batch, masks_enc, masks_pred = DefaultCollator()(
+        [torch.tensor([1]), torch.tensor([2])]
+    )
 
     assert batch.shape == (2, 1)
     assert masks_enc is None
@@ -19,7 +34,8 @@ def test_random_mask_collator_splits_patch_indices():
     assert batch.shape == (2, 1)
     assert masks_enc.shape == (2, 2)
     assert masks_pred.shape == (2, 2)
-    assert torch.cat([masks_enc[0], masks_pred[0]]).sort().values.tolist() == [0, 1, 2, 3]
+    combined = torch.cat([masks_enc[0], masks_pred[0]]).sort().values.tolist()
+    assert combined == [0, 1, 2, 3]
 
 
 def test_multiblock_mask_collator_returns_batched_masks():
@@ -38,7 +54,5 @@ def test_multiblock_mask_collator_returns_batched_masks():
     batch, masks_enc, masks_pred = collator([torch.zeros(1), torch.ones(1)])
 
     assert batch.shape == (2, 1)
-    assert masks_enc.shape[0:2] == (2, 1)
-    assert masks_pred.shape[0:2] == (2, 1)
-    assert masks_enc.numel() > 0
-    assert masks_pred.numel() > 0
+    _assert_mask_collection(masks_enc, batch_size=2, num_masks=1)
+    _assert_mask_collection(masks_pred, batch_size=2, num_masks=1)

--- a/tests/models/test_dit.py
+++ b/tests/models/test_dit.py
@@ -1,0 +1,29 @@
+import torch
+
+from world_models.configs.dit_config import DiTConfig
+from world_models.models.diffusion.DiT import DiT, PatchEmbed, PatchUnEmbed, create_dit
+
+
+def test_create_dit_builds_small_model_from_config_and_runs_forward():
+    config = DiTConfig(
+        IMG_SIZE=8, PATCH=4, CHANNELS=3, WIDTH=16, DEPTH=1, HEADS=4, DROP=0.0
+    )
+    model = create_dit(config)
+
+    assert isinstance(model, DiT)
+    x = torch.randn(2, 3, 8, 8)
+    t = torch.tensor([0, 10])
+    out = model(x, t)
+
+    assert out.shape == x.shape
+
+
+def test_patch_embed_unembed_round_trip_shape():
+    patch = PatchEmbed(img_size=8, patch_size=4, in_channels=3, embed_dim=12)
+    unpatch = PatchUnEmbed(img_size=8, patch_size=4, embed_dim=12, out_channels=3)
+
+    tokens = patch(torch.randn(2, 3, 8, 8))
+    images = unpatch(tokens)
+
+    assert tokens.shape == (2, 4, 12)
+    assert images.shape == (2, 3, 8, 8)

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -1,0 +1,29 @@
+import tomllib
+from pathlib import Path
+
+
+def _dependency_names(dependencies):
+    names = []
+    for dependency in dependencies:
+        if isinstance(dependency, str):
+            names.append(dependency.split(">=", maxsplit=1)[0])
+        else:
+            names.append(dependency["name"])
+    return names
+
+
+def test_jax_is_brax_optional_dependency_not_core_dependency():
+    project = tomllib.loads(Path("pyproject.toml").read_text())["project"]
+
+    assert "jax" not in _dependency_names(project["dependencies"])
+    assert "jax" in _dependency_names(project["optional-dependencies"]["brax"])
+
+
+def test_lockfile_keeps_jax_out_of_core_torchwm_dependencies():
+    lock = tomllib.loads(Path("uv.lock").read_text())
+    torchwm = next(
+        package for package in lock["package"] if package["name"] == "torchwm"
+    )
+
+    assert "jax" not in _dependency_names(torchwm["dependencies"])
+    assert "jax" in _dependency_names(torchwm["optional-dependencies"]["brax"])

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -63,3 +63,55 @@ def test_create_model_for_factory_only_spec_filters_through_signature(monkeypatc
         "required": 3,
         "optional": 5,
     }
+
+
+def test_diamond_and_dit_are_registered_in_public_api():
+    assert "diamond" in torchwm.list_models()
+    assert "dit" in torchwm.list_models()
+
+    diamond_cfg = torchwm.create_config("diamond", game="Pong-v5", seed=11)
+    dit_cfg = torchwm.create_config("diffusion-transformer", IMG_SIZE=8, PATCH=4)
+
+    assert diamond_cfg.game == "Pong-v5"
+    assert diamond_cfg.seed == 11
+    assert dit_cfg.IMG_SIZE == 8
+    assert dit_cfg.PATCH == 4
+    assert torchwm.get_model_spec("diamond_agent").name == "diamond"
+    assert torchwm.get_model_spec("diffusion_transformer").name == "dit"
+
+
+def test_create_model_uses_dit_config_adapter():
+    model = torchwm.create_model(
+        "dit",
+        IMG_SIZE=8,
+        PATCH=4,
+        CHANNELS=3,
+        WIDTH=16,
+        DEPTH=1,
+        HEADS=4,
+        DROP=0.0,
+    )
+
+    assert model.patchify.proj.in_channels == 3
+    assert len(model.transformer_blocks) == 1
+
+
+def test_create_model_dispatches_diamond_agent_with_config(monkeypatch):
+    captured = {}
+
+    class FakeDiamondAgent:
+        def __init__(self, config):
+            captured["config"] = config
+
+    original_loader = api._load_object
+
+    def fake_loader(import_path):
+        if import_path == "world_models.training.train_diamond:DiamondAgent":
+            return FakeDiamondAgent
+        return original_loader(import_path)
+
+    monkeypatch.setattr(api, "_load_object", fake_loader)
+    agent = api.create_model("diamond", game="Pong-v5")
+
+    assert isinstance(agent, FakeDiamondAgent)
+    assert captured["config"].game == "Pong-v5"

--- a/uv.lock
+++ b/uv.lock
@@ -4189,7 +4189,6 @@ dependencies = [
     { name = "gymnasium" },
     { name = "h5py" },
     { name = "huggingface-hub" },
-    { name = "jax" },
     { name = "moviepy" },
     { name = "opencv-python" },
     { name = "playwright" },
@@ -4234,6 +4233,7 @@ all = [
 ]
 brax = [
     { name = "brax" },
+    { name = "jax" },
 ]
 dev = [
     { name = "mypy" },
@@ -4286,7 +4286,7 @@ requires-dist = [
     { name = "h5py", specifier = ">=3.11.0" },
     { name = "huggingface-hub", specifier = ">=1.14.0" },
     { name = "huggingface-hub", marker = "extra == 'gym'", specifier = ">=0.23.0" },
-    { name = "jax", specifier = ">=0.10.1" },
+    { name = "jax", marker = "extra == 'brax'", specifier = ">=0.10.1" },
     { name = "mlagents-envs", marker = "extra == 'ml-agents'", specifier = ">=0.28.0" },
     { name = "moviepy", specifier = ">=2.2.1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.19.1" },

--- a/world_models/__init__.py
+++ b/world_models/__init__.py
@@ -81,6 +81,7 @@ _LAZY_EXPORTS: dict[str, str] = {
     "IRISOnPolicyBuffer": "world_models.memory",
     # Diffusion models.
     "DiT": "world_models.models.diffusion",
+    "create_dit": "world_models.models.diffusion",
     "PatchEmbed": "world_models.models.diffusion",
     "PatchUnEmbed": "world_models.models.diffusion",
     "DDPM": "world_models.models.diffusion",

--- a/world_models/api.py
+++ b/world_models/api.py
@@ -80,6 +80,20 @@ MODEL_SPECS: dict[str, ModelSpec] = {
         description="Large Genie variant.",
         aliases=("genie_large",),
     ),
+    "diamond": ModelSpec(
+        name="diamond",
+        import_path="world_models.training.train_diamond:DiamondAgent",
+        config_path="world_models.configs.diamond_config:DiamondConfig",
+        description="DIAMOND diffusion world model agent for Atari-style control.",
+        aliases=("diamond_agent",),
+    ),
+    "dit": ModelSpec(
+        name="dit",
+        import_path="world_models.models.diffusion.DiT:create_dit",
+        config_path="world_models.configs.dit_config:DiTConfig",
+        description="Diffusion Transformer (DiT) image denoising model.",
+        aliases=("diffusion-transformer", "diffusion_transformer"),
+    ),
     "modular-rssm": ModelSpec(
         name="modular-rssm",
         import_path="world_models.models.modular_rssm:create_modular_rssm",

--- a/world_models/models/diffusion/DiT.py
+++ b/world_models/models/diffusion/DiT.py
@@ -373,3 +373,43 @@ class DiT(nn.Module):
             os.makedirs(workdir, exist_ok=True)
             save_image((samples + 1) / 2, f"{workdir}/generated_samples.png", nrow=4)
             print(f"Generated samples saved to {workdir}/generated_samples.png")
+
+
+def create_dit(config=None, **overrides):
+    """Create a :class:`DiT` from a ``DiTConfig`` or keyword overrides.
+
+    The public factory API works with config objects, while ``DiT`` itself has a
+    compact constructor. This adapter keeps the lower-level model constructor
+    unchanged and maps the public config fields onto the expected arguments.
+    """
+
+    if config is None:
+        config = Config()
+
+    config_fields = set(getattr(config, "__dataclass_fields__", {}))
+    config_overrides = {
+        key: value for key, value in overrides.items() if key in config_fields
+    }
+    constructor_overrides = {
+        key: value for key, value in overrides.items() if key not in config_fields
+    }
+    if config_overrides:
+        from dataclasses import replace
+
+        config = replace(config, **config_overrides)
+
+    kwargs = {
+        "img_size": config.IMG_SIZE,
+        "patch_size": config.PATCH,
+        "in_channels": config.CHANNELS,
+        "d_model": config.WIDTH,
+        "depth": config.DEPTH,
+        "heads": config.HEADS,
+        "drop": config.DROP,
+    }
+    supported = set(kwargs) | {"t_dim"}
+    invalid = sorted(set(constructor_overrides) - supported)
+    if invalid:
+        raise ValueError(f"Unsupported DiT argument(s): {', '.join(invalid)}")
+    kwargs.update(constructor_overrides)
+    return DiT(**kwargs)

--- a/world_models/models/diffusion/__init__.py
+++ b/world_models/models/diffusion/__init__.py
@@ -13,6 +13,7 @@ Exported Components:
 
 __all__ = [
     "DiT",
+    "create_dit",
     "PatchEmbed",
     "PatchUnEmbed",
     "DDPM",
@@ -27,6 +28,10 @@ def __getattr__(name):
         from .DiT import DiT
 
         return DiT
+    if name == "create_dit":
+        from .DiT import create_dit
+
+        return create_dit
     if name == "PatchEmbed":
         from .DiT import PatchEmbed
 


### PR DESCRIPTION
### Motivation
- Allow high-level factories `create_config` / `create_model` to discover and instantiate DIAMOND and DiT via the public API. 
- Reduce install burden by moving `jax` out of the core dependencies and into the `brax` optional extra. 
- Make coverage meaningful by tracking `world_models`/`torchwm` and removing blanket exclusions. 
- Close obvious CI gaps by adding small smoke tests for diffusion, masks, envs, and optional-dependency metadata. 

### Description
- Registered `diamond` and `dit` in `MODEL_SPECS` so `create_config("diamond")`, `create_model("diamond")`, `create_config("dit")`, and `create_model("dit")` resolve through `world_models/api.py`. 
- Added a `create_dit` factory adapter in `world_models/models/diffusion/DiT.py` and exported it via the diffusion package and top-level lazy exports so the public API can construct `DiT` from a `DiTConfig` or overrides. 
- Moved `jax>=0.10.1` out of the core `dependencies` in `pyproject.toml` into the `brax` optional extra and updated `uv.lock` metadata to match. 
- Added a tracked `.coveragerc` (no blanket exclusions) and removed `.coveragerc` from `.gitignore`. 
- Introduced smoke tests: `tests/test_public_api.py` (register/dispatch checks), `tests/models/test_dit.py` (DiT forward & patch round-trip), `tests/masks/test_masks.py` (mask collators), `tests/envs/test_envs.py` (mocked DMC smoke), and `tests/test_optional_dependencies.py` (dependency metadata). 

### Testing
- `python -m py_compile world_models/api.py world_models/models/diffusion/DiT.py tests/test_public_api.py tests/test_optional_dependencies.py tests/models/test_dit.py tests/masks/test_masks.py tests/envs/test_envs.py` succeeded. 
- `pytest -q tests/test_optional_dependencies.py` passed (1 test file validating `jax` is only in the `brax` extra). 
- Attempted `pytest` runs that would execute the new smoke tests were blocked during collection in this environment due to missing heavy runtime dependencies (`torch`, `gymnasium`) so full pytest of the new tests could not be completed here. 
- `uv lock --offline` / `uv lock` attempts were blocked by the environment (network/cache) when checking lock resolution for some packages (notably `ale-py`), but `uv.lock` metadata was updated in the branch to reflect the optionalization of `jax`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a276c7578f483279194bdb17dc7042b)