### PR TITLE
Improve block exports and testing utilities

### DIFF
--- a/tests/blocks/test_blocks_exports.py
+++ b/tests/blocks/test_blocks_exports.py
@@ -1,0 +1,25 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+import world_models.blocks as blocks
+
+
+def test_blocks_all_exports_are_resolvable():
+    for name in blocks.__all__:
+        assert getattr(blocks, name) is not None
+
+
+def test_spatiotemporal_attention_exports_preserve_shapes():
+    x = torch.randn(2, 3, 4, 8)
+
+    spatial = blocks.STSpatialAttention(dim=8, num_heads=2)
+    temporal = blocks.STTemporalAttention(dim=8, num_heads=2)
+
+    assert spatial(x).shape == x.shape
+    assert temporal(x).shape == x.shape
+
+
+def test_backwards_compatible_aliases_point_to_real_classes():
+    assert blocks.MultiHeadAttention is blocks.MultiHeadSelfAttention
+    assert blocks.STBlock is blocks.STTransformerBlock

--- a/tests/testing/test_mocking_classes.py
+++ b/tests/testing/test_mocking_classes.py
@@ -1,0 +1,46 @@
+import numpy as np
+import pytest
+
+from world_models.testing import MockBoxSpace, MockDiscreteSpace, MockImageEnv
+
+
+def test_mock_discrete_space_is_deterministic_and_validates_membership():
+    space = MockDiscreteSpace(n=3, sample_value=2)
+
+    assert space.sample() == 2
+    assert space.contains(0)
+    assert not space.contains(3)
+
+
+def test_mock_box_space_samples_midpoint_and_checks_bounds():
+    space = MockBoxSpace(shape=(2, 2), low=-1.0, high=1.0)
+    sample = space.sample()
+
+    assert sample.shape == (2, 2)
+    assert np.all(sample == 0.0)
+    assert space.contains(sample)
+    assert not space.contains(np.full((2, 2), 2.0))
+
+
+def test_mock_image_env_follows_gymnasium_step_api():
+    env = MockImageEnv(image_shape=(4, 4, 3), action_dim=2, episode_length=2)
+
+    observation, info = env.reset()
+    assert observation.shape == (4, 4, 3)
+    assert info == {}
+
+    observation, reward, terminated, truncated, info = env.step(1)
+    assert observation.shape == (4, 4, 3)
+    assert reward == 1.0
+    assert not terminated
+    assert not truncated
+    assert info == {}
+
+    _, _, terminated, _, _ = env.step(0)
+    assert terminated
+
+    with pytest.raises(ValueError):
+        env.step(2)
+
+    env.close()
+    assert env.closed

--- a/world_models/blocks/__init__.py
+++ b/world_models/blocks/__init__.py
@@ -6,11 +6,12 @@ Exported Components:
         - STTransformer: Spatiotemporal Transformer for video processing
         - STSpatialAttention: Spatial attention layer
         - STTemporalAttention: Temporal attention layer
-        - STBlock: Combined spatiotemporal transformer block
+        - STTransformerBlock: Combined spatiotemporal transformer block
+        - STBlock: Backwards-compatible alias for STTransformerBlock
 
     Attention:
         - MultiHeadSelfAttention: Multi-head self-attention
-        - MultiHeadAttention: Generic multi-head attention (alias)
+        - MultiHeadAttention: Backwards-compatible alias for MultiHeadSelfAttention
         - Attention: Attention mechanism
 
     Normalization:
@@ -22,6 +23,10 @@ __all__ = [
     # Transformers
     "STTransformer",
     "STSpatialAttention",
+    "STTemporalAttention",
+    "STTransformerBlock",
+    "STBlock",
+    # Attention
     "MultiHeadSelfAttention",
     "MultiHeadAttention",
     # Normalization
@@ -40,6 +45,18 @@ def __getattr__(name):
         from .st_transformer import STSpatialAttention
 
         return STSpatialAttention
+    if name == "STTemporalAttention":
+        from .st_transformer import STTemporalAttention
+
+        return STTemporalAttention
+    if name == "STTransformerBlock":
+        from .st_transformer import STTransformerBlock
+
+        return STTransformerBlock
+    if name == "STBlock":
+        from .st_transformer import STTransformerBlock
+
+        return STTransformerBlock
 
     # Attention
     if name == "MultiHeadSelfAttention":
@@ -49,7 +66,7 @@ def __getattr__(name):
     if name == "MultiHeadAttention":
         from .mhsa import MultiHeadSelfAttention
 
-        return MultiHeadSelfAttention  # Alias
+        return MultiHeadSelfAttention
 
     # Normalization
     if name == "RMSNorm":

--- a/world_models/catalog.py
+++ b/world_models/catalog.py
@@ -7,7 +7,10 @@ dependencies.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 DREAMER_ENVS = [
     "cartpole-balance",
@@ -33,6 +36,7 @@ def _iter_gymnasium_registry() -> list[tuple[str, Any]]:
     try:
         import gymnasium as gym
     except Exception:
+        logger.debug("Gymnasium registry unavailable", exc_info=True)
         return []
 
     registry = getattr(getattr(gym, "envs", None), "registry", {})
@@ -112,6 +116,7 @@ def _list_available_robotics_envs() -> list[str]:
 
         return list_gymnasium_robotics_envs()
     except Exception:
+        logger.debug("Gymnasium Robotics environments unavailable", exc_info=True)
         return []
 
 
@@ -146,6 +151,7 @@ def _list_available_bsuite_ids() -> list[str]:
 
         return list_available_bsuite_ids()
     except Exception:
+        logger.debug("BSuite environment ids unavailable; using examples", exc_info=True)
         return [
             "bandit/0",
             "cartpole/0",
@@ -169,6 +175,7 @@ def _list_available_atari_envs() -> list[str]:
 
         return list_available_atari_envs()
     except Exception:
+        logger.debug("Atari environment ids unavailable", exc_info=True)
         return []
 
 
@@ -181,6 +188,7 @@ def _list_available_dmlab_levels() -> list[str]:
 
         return list(DMLAB_LEVELS)
     except Exception:
+        logger.debug("DeepMind Lab levels unavailable", exc_info=True)
         return []
 
 

--- a/world_models/envs/__init__.py
+++ b/world_models/envs/__init__.py
@@ -35,6 +35,9 @@ from .wrappers import (
 )
 from .dmc import DeepMindControlEnv
 import gym
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def make_env(env_id: str, **kwargs):
@@ -59,32 +62,32 @@ def make_env(env_id: str, **kwargs):
     try:
         return make_gym_env(env_id, **kwargs)
     except Exception:
-        pass
+        logger.debug("make_gym_env could not create %s", env_id, exc_info=True)
 
     try:
         return make_robotics_env(env_id, **kwargs)
     except Exception:
-        pass
+        logger.debug("make_robotics_env could not create %s", env_id, exc_info=True)
 
     try:
         return make_atari_env(env_id, **kwargs)
     except Exception:
-        pass
+        logger.debug("make_atari_env could not create %s", env_id, exc_info=True)
 
     try:
         return make_procgen_env(env_id, **kwargs)
     except Exception:
-        pass
+        logger.debug("make_procgen_env could not create %s", env_id, exc_info=True)
 
     try:
         return make_unity_mlagents_env(env_id, **kwargs)
     except Exception:
-        pass
+        logger.debug("make_unity_mlagents_env could not create %s", env_id, exc_info=True)
 
     try:
         return make_bsuite_env(env_id, **kwargs)
     except Exception:
-        pass
+        logger.debug("make_bsuite_env could not create %s", env_id, exc_info=True)
 
     # Fall back to gym.
     return gym.make(env_id, **kwargs)

--- a/world_models/testing/__init__.py
+++ b/world_models/testing/__init__.py
@@ -1,0 +1,5 @@
+"""Testing utilities for torchwm."""
+
+from .mocking_classes import MockBoxSpace, MockDiscreteSpace, MockImageEnv
+
+__all__ = ["MockBoxSpace", "MockDiscreteSpace", "MockImageEnv"]

--- a/world_models/testing/mocking_classes.py
+++ b/world_models/testing/mocking_classes.py
@@ -1,0 +1,110 @@
+"""Reusable lightweight test doubles for environment-facing tests.
+
+The helpers in this module intentionally avoid importing Gym/Gymnasium so tests
+can build deterministic mock environments without optional runtime backends.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+
+@dataclass(slots=True)
+class MockDiscreteSpace:
+    """Small stand-in for Gym's discrete action space."""
+
+    n: int
+    sample_value: int = 0
+
+    def sample(self) -> int:
+        """Return a deterministic action inside the space."""
+        if not 0 <= self.sample_value < self.n:
+            raise ValueError("sample_value must be in [0, n)")
+        return self.sample_value
+
+    def contains(self, value: Any) -> bool:
+        """Return whether ``value`` is a valid discrete action."""
+        return isinstance(value, (int, np.integer)) and 0 <= int(value) < self.n
+
+
+@dataclass(slots=True)
+class MockBoxSpace:
+    """Small stand-in for Gym's Box space with deterministic samples."""
+
+    shape: tuple[int, ...]
+    low: float = 0.0
+    high: float = 1.0
+    dtype: type[np.generic] | np.dtype = np.float32
+
+    def sample(self) -> np.ndarray:
+        """Return the midpoint of the box for deterministic tests."""
+        midpoint = (self.low + self.high) / 2.0
+        return np.full(self.shape, midpoint, dtype=self.dtype)
+
+    def contains(self, value: Any) -> bool:
+        """Return whether ``value`` has this shape and lies within bounds."""
+        arr = np.asarray(value)
+        return (
+            arr.shape == self.shape
+            and bool(np.all(arr >= self.low))
+            and bool(np.all(arr <= self.high))
+        )
+
+
+class MockImageEnv:
+    """Deterministic image-observation environment for unit tests.
+
+    The class mimics the small subset of the Gym API used throughout the test
+    suite: ``reset()``, ``step()``, ``render()``, ``close()``, and the
+    ``observation_space``/``action_space`` attributes.
+    """
+
+    metadata = {"render_modes": ["rgb_array"]}
+
+    def __init__(
+        self,
+        image_shape: tuple[int, int, int] = (64, 64, 3),
+        action_dim: int = 2,
+        episode_length: int = 5,
+        reward: float = 1.0,
+    ) -> None:
+        self.image_shape = image_shape
+        self.episode_length = episode_length
+        self.reward = reward
+        self.observation_space = MockBoxSpace(
+            image_shape, low=0, high=255, dtype=np.uint8
+        )
+        self.action_space = MockDiscreteSpace(action_dim)
+        self.steps = 0
+        self.closed = False
+
+    def _observation(self) -> np.ndarray:
+        return np.full(self.image_shape, self.steps % 256, dtype=np.uint8)
+
+    def reset(self, *, seed: int | None = None, options: dict[str, Any] | None = None):
+        """Reset the environment and return a Gymnasium-style tuple."""
+        del seed, options
+        self.steps = 0
+        return self._observation(), {}
+
+    def step(self, action: Any):
+        """Advance one step and return a Gymnasium-style transition."""
+        if not self.action_space.contains(action):
+            raise ValueError(f"Invalid action for MockImageEnv: {action!r}")
+        self.steps += 1
+        terminated = self.steps >= self.episode_length
+        return self._observation(), self.reward, terminated, False, {}
+
+    def render(self) -> np.ndarray:
+        """Return the current observation as an RGB array."""
+        return self._observation()
+
+    def close(self) -> None:
+        """Mark the environment as closed."""
+        self.closed = True
+
+
+__all__ = ["MockBoxSpace", "MockDiscreteSpace", "MockImageEnv"]


### PR DESCRIPTION
### Motivation
- Make block exports robust and backwards-compatible so consumers can reliably import temporal/spatiotemporal transformer components and aliases.
- Replace silent exception swallowing in environment discovery with debug logging to improve observability during optional-backend probing.
- Provide lightweight, deterministic test doubles to make environment-facing unit tests import-safe and not depend on optional runtime backends.

### Description
- Added missing lazy exports and backwards-compatible aliases in `world_models.blocks.__init__` so `STTemporalAttention`, `STTransformerBlock`, and `STBlock` are in `__all__` and resolvable via `__getattr__`, and clarified the `MultiHeadAttention` alias.\
- Replaced silent `except Exception:` fallbacks in `world_models/envs.__init__::make_env` and optional-backend discovery in `world_models/catalog.py` with `logger.debug(...)` calls to surface failures when optional factories are unavailable.\
- Implemented deterministic mocking helpers in `world_models/testing/mocking_classes.py` (`MockDiscreteSpace`, `MockBoxSpace`, `MockImageEnv`) and re-exported them in `world_models/testing.__init__`.\
- Added focused unit tests `tests/blocks/test_blocks_exports.py` and `tests/testing/test_mocking_classes.py` to validate block exports/aliases, attention shapes, and the mocking utilities.\

### Testing
- Compiled modified modules with `PYTHONPATH=. python -m py_compile world_models/blocks/__init__.py world_models/catalog.py world_models/envs/__init__.py world_models/testing/__init__.py world_models/testing/mocking_classes.py` and it succeeded.\
- Ran the new targeted test suite with `PYTHONPATH=. pytest -q tests/blocks/test_blocks_exports.py tests/testing/test_mocking_classes.py` which passed with `3 passed, 1 skipped` (the skip is the `torch`-dependent test when `torch` is not installed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2aeec21c2883278c9199287fad2861)