### PR TITLE
Harden checkpoint and replay loading

### DIFF
--- a/world_models/configs/dreamer_config.py
+++ b/world_models/configs/dreamer_config.py
@@ -121,6 +121,10 @@ class DreamerConfig:
         self.wandb_project = "torchwm"
         self.wandb_entity = ""
         self.log_dir = "runs"
+        # Base directory for DreamerAgent-created relative log directories.
+        # If unset, DreamerAgent uses TORCHWM_DATA_DIR or log_dir instead of
+        # writing into the package source tree.
+        self.data_dir = None
         self.log_level = "INFO"
         self.log_file = None
         self.enable_tensorboard = False

--- a/world_models/models/dreamer.py
+++ b/world_models/models/dreamer.py
@@ -690,7 +690,7 @@ class Dreamer:
         )
 
     def restore_checkpoint(self, ckpt_path):
-        checkpoint = torch.load(ckpt_path)
+        checkpoint = torch.load(ckpt_path, weights_only=True)
         self.rssm.load_state_dict(checkpoint["rssm"])
         self.actor.load_state_dict(checkpoint["actor"])
         self.reward_model.load_state_dict(checkpoint["reward_model"])
@@ -733,10 +733,19 @@ class DreamerAgent(ExportableAgentMixin):
                     pass
             elif key == "last_latents_ref":
                 self.last_latents_ref = value
+            elif key == "data_path":
+                # Backwards-compatible alias for the new configurable data_dir.
+                setattr(self.args, "data_dir", value)
             else:
                 raise ValueError(f"Invalid argument: {key}")
 
-        data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "data/")
+        data_path = (
+            getattr(self.args, "data_dir", None)
+            or os.environ.get("TORCHWM_DATA_DIR")
+            or getattr(self.args, "log_dir", None)
+            or "runs"
+        )
+        data_path = os.path.abspath(os.path.expanduser(data_path))
 
         if not (os.path.exists(data_path)):
             os.makedirs(data_path)
@@ -757,7 +766,8 @@ class DreamerAgent(ExportableAgentMixin):
                 + time.strftime("%d-%m-%Y-%H-%M-%S")
             )
 
-        # If `self.logdir` is not an absolute path, place it under package data_path
+        # If `self.logdir` is not an absolute path, place it under the
+        # configurable data directory instead of the package source tree.
         if not os.path.isabs(self.logdir):
             self.logdir = os.path.join(data_path, self.logdir)
         if not (os.path.exists(self.logdir)):

--- a/world_models/training/train_diamond.py
+++ b/world_models/training/train_diamond.py
@@ -819,13 +819,11 @@ class DiamondAgent:
                 else:
                     raise FileNotFoundError(f"Checkpoint not found at {path} or {alt}")
 
-        # Use full (unsafe) load to restore Python objects (numpy arrays, lists)
-        # required for replay buffer and obs history restoration.
-        # Load the torch checkpoint (weights + metadata). This file should be
-        # safe to load because it contains only tensor state dicts and small
-        # metadata fields. Larger numpy arrays may be stored separately and
-        # are loaded below when present.
-        checkpoint = torch.load(fpath, map_location=self.device, weights_only=False)
+        # The checkpoint stores tensor state_dicts and primitive metadata only;
+        # larger replay/observation arrays are loaded from separate npz/npy
+        # files below. Keep torch deserialization in weights-only mode to avoid
+        # executing arbitrary pickle payloads from untrusted checkpoints.
+        checkpoint = torch.load(fpath, map_location=self.device, weights_only=True)
         self.diffusion_model.load_state_dict(checkpoint["diffusion_model"])
         self.reward_model.load_state_dict(checkpoint["reward_model"])
         self.actor_critic.load_state_dict(checkpoint["actor_critic"])

--- a/world_models/training/train_genie.py
+++ b/world_models/training/train_genie.py
@@ -254,7 +254,7 @@ class GenieTrainer:
         checkpoint = torch.load(
             path,
             map_location=self.device,
-            weights_only=False,
+            weights_only=True,
         )
         self.model.load_state_dict(checkpoint["model_state_dict"])
         self.optimizer.load_state_dict(checkpoint["optimizer_state_dict"])

--- a/world_models/utils/utils.py
+++ b/world_models/utils/utils.py
@@ -32,6 +32,33 @@ import umap
 HAS_VIZ = True
 
 
+class _RestrictedReplayUnpickler(pickle.Unpickler):
+    """Unpickler that only resolves classes needed by replay buffers."""
+
+    _ALLOWED_GLOBALS = {
+        ("builtins", "dict"),
+        ("builtins", "list"),
+        ("builtins", "set"),
+        ("builtins", "slice"),
+        ("builtins", "tuple"),
+        ("collections", "deque"),
+        ("numpy", "dtype"),
+        ("numpy", "ndarray"),
+        ("numpy.core.multiarray", "_reconstruct"),
+        ("numpy._core.multiarray", "_reconstruct"),
+        ("world_models.memory.planet_memory", "Episode"),
+        ("world_models.memory.planet_memory", "Memory"),
+        ("world_models.memory.planet_memory", "_identity"),
+    }
+
+    def find_class(self, module, name):
+        if (module, name) in self._ALLOWED_GLOBALS:
+            return super().find_class(module, name)
+        raise pickle.UnpicklingError(
+            f"global '{module}.{name}' is not allowed in replay buffers"
+        )
+
+
 class AttrDict(dict):
     def __getattr__(self, name):
         try:
@@ -369,13 +396,24 @@ def get_mask(tensor, lengths):
     return mask
 
 
-def load_memory(path, device):
+def load_memory(path, device, *, trusted=False):
     """
-    Loads an experience replay buffer (backwards-compatible with older pickle formats).
+    Loads an experience replay buffer.
+
+    Pickle can execute arbitrary code during unrestricted deserialization. By
+    default this uses a restricted unpickler that only allows the replay buffer
+    classes and numpy containers required by historical buffers. Pass
+    ``trusted=True`` only for files created by this application or another
+    trusted source when compatibility with a legacy pickle requires unrestricted
+    loading.
+
     Converts legacy list/.data formats into the current Memory(episodes) object.
     """
     with open(path, "rb") as f:
-        memory = pickle.load(f)
+        if trusted:
+            memory = pickle.Unpickler(f).load()
+        else:
+            memory = _RestrictedReplayUnpickler(f).load()
 
     # If file contains a plain list of Episode objects -> wrap into Memory
     if isinstance(memory, list):


### PR DESCRIPTION
### Motivation
- Prevent arbitrary code execution when loading replay buffers with `pickle.load` by restricting unpickling to known-safe replay types.
- Avoid unsafe full deserialization when restoring model checkpoints by loading only weights where possible.
- Stop writing Dreamer logs/data into the package source tree by making the base data/log directory configurable.

### Description
- Add a `_RestrictedReplayUnpickler` and change `load_memory` in `world_models/utils/utils.py` to use the restricted unpickler by default with an explicit `trusted=True` opt-in for legacy cases.
- Change checkpoint restore calls to use `torch.load(..., weights_only=True)` in `world_models/training/train_diamond.py`, `world_models/training/train_genie.py`, and `world_models/models/dreamer.py` to avoid unsafe pickle execution.
- Add a `data_dir` config option in `world_models/configs/dreamer_config.py` and update `DreamerAgent` in `world_models/models/dreamer.py` to use `data_dir` / `TORCHWM_DATA_DIR` / `log_dir` (and accept a backwards-compatible `data_path` alias) for its base data/log directory.
- Update docstrings and comments to explain the security and compatibility decisions.

### Testing
- Ran byte-compilation on modified files with `python -m py_compile world_models/utils/utils.py world_models/training/train_diamond.py world_models/training/train_genie.py world_models/models/dreamer.py world_models/configs/dreamer_config.py`, which succeeded.
- Attempted an automated runtime test that exercises `load_memory` with a benign and a malicious pickle to verify the restricted unpickler, but the run was blocked by a missing runtime dependency (`torch` not installed) and could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2aef02e49c83279752d2b9943ba485)