### PR TITLE
Fix CI workflows, labeler globs, and docs dependency configuration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,55 +1,59 @@
 config:
-  - world_models/configs/*
+  - world_models/configs/**
 
 # Add 'environment' to any changes to environment files
 environment:
-  - world_models/envs/*
+  - world_models/envs/**
 
 trainer:
-  - world_models/training/*
+  - world_models/training/**
 
 controller:
-  - world_models/controller/*
+  - world_models/controller/**
 
 helpers:
-  - world_models/helpers/*
+  - world_models/helpers/**
 
 tokenizers:
-  - world_models/tokenizers/*
+  - world_models/vision/video_tokenizer.py
+  - world_models/vision/vq_layer.py
 
 tests:
-  - tests/*
-  - world_models/testing/*
+  - tests/**
+  - world_models/testing/**
 
 models:
-  - world_models/models/*
+  - world_models/models/**
 
 memory:
-  - world_models/memory/*
+  - world_models/memory/**
 
 masks:
-  - world_models/masks/*
+  - world_models/masks/**
 
 reward_functions:
-  - world_models/reward/*
+  - world_models/reward/**
 
 observation_wrappers:
-  - world_models/observations/*
+  - world_models/observations/**
 
 utilities:
-  - world_models/utils/*
+  - world_models/utils/**
 
 vision:
-  - world_models/vision/*
+  - world_models/vision/**
 
 transforms:
-  - world_models/transforms/*
-# Add 'CI/CD' to any changes to GitHub workflows
+  - world_models/transforms/**
+
+# Add 'CI/CD' to any changes to GitHub workflows and automation config
 CI/CD:
-  - .github/workflows/*
+  - .github/workflows/**
+  - .github/*.yml
 
 # Add 'documentation' to any changes to documentation files
 documentation:
   - README.md
   - CITATION.cff
   - LICENSE
+  - docs/**

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -9,14 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.13'
+          cache: 'pip'
 
       - name: Install flake8
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,10 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.13'
+        cache: 'pip'
+        cache-dependency-path: |
+          pyproject.toml
+          setup.py
 
     - name: Install dependencies
       run: |

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     include_package_data=True,
     package_data={"world_models": ["configs/experiments/*.yaml"]},
     entry_points={"console_scripts": ["torchwm=tools.cli:run"]},
-    python_requires=">=3.10",
+    python_requires=">=3.11",
     install_requires=[
         "torch>=1.13.0",
         "torchvision>=0.14.0",
@@ -96,6 +96,7 @@ setup(
             "sphinx>=9.1.0",
             "sphinx-autodoc-typehints>=3.6.2",
             "sphinx-copybutton>=0.5.2",
+            "pydata-sphinx-theme>=0.15.0",
             "sphinx-rtd-theme>=3.1.0",
             "sphinxcontrib-bibtex>=2.6.5",
             "sphinxcontrib-mermaid>=0.9.0",


### PR DESCRIPTION
### Motivation
- CI and automation were misconfigured: labeler globs referenced non-existent paths and non-recursive patterns, the lint workflow used Python 3.8 and lived outside `.github/workflows`, and the test workflow lacked pip caching which slowed CI.  
- Documentation builds failed because `pydata_sphinx_theme` was used in `docs/source/conf.py` but not declared in package extras.  
- The package metadata and workflows needed alignment with the repo `pyproject.toml` Python requirement.  

### Description
- Updated `.github/labeler.yml` to use recursive globs (`**`) for existing repo paths and map tokenizer labels to actual tokenizer files (`world_models/vision/video_tokenizer.py`, `world_models/vision/vq_layer.py`).  
- Moved the lint workflow into `.github/workflows/linter.yml` (renamed from `.github/linter.yml`), upgraded actions to `actions/checkout@v4` and `actions/setup-python@v5`, set `python-version: '3.13'`, and enabled pip caching via `cache: 'pip'`.  
- Enabled pip caching for the pytest workflow in `.github/workflows/test.yml` by adding `cache: 'pip'` and `cache-dependency-path` entries for `pyproject.toml` and `setup.py`.  
- Aligned `setup.py` with `pyproject.toml` by changing `python_requires` from `>=3.10` to `>=3.11` and added the missing docs extra `pydata-sphinx-theme>=0.15.0` so Sphinx can use the configured theme.  

### Testing
- Ran a YAML and glob validation script (`python - <<'PY' ... PY`) to parse workflow YAML, ensure labeler patterns match actual files, check Dockerfile for forbidden UI references, and verify `COPY` sources exist; the script completed successfully.  
- Compiled `setup.py` with `python -m py_compile setup.py` which succeeded.  
- Ran `git diff --check` to ensure no whitespace or diff issues; the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bf027f5d08327b4e4e937fb2aa9ff)