### PR TITLE
docs: sync config reference, starter YAMLs, and contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to TorchWM
 
-We welcome contributions to torchwm! This document outlines the guidelines for contributing to the project.
+We welcome contributions to TorchWM! This document outlines the guidelines for contributing to the project.
 
 ## Ways to Contribute
 
@@ -16,26 +16,36 @@ We welcome contributions to torchwm! This document outlines the guidelines for c
    cd torchwm
    ```
 
-2. Install dependencies in editable mode with development extras:
+2. Install dependencies with development extras:
    ```bash
-   pip install -e ".[dev]"
+   uv sync --dev
    ```
 
 3. Set up pre-commit hooks:
    ```bash
-   pre-commit install
+   uv run pre-commit install
    ```
+
+If you are not using `uv`, install the project in editable mode with development extras instead:
+
+```bash
+python -m pip install -e ".[dev]"
+pre-commit install
+```
 
 ## Coding Standards
 
 - Follow PEP 8 style guidelines.
 - Use type hints where possible.
-- Ensure code is linted with Ruff: `ruff check .`
-- Format code with Ruff: `ruff format .`
+- Format code with Black: `uv run black .`
+- Lint code with Ruff: `uv run ruff check .`
+- Type-check code with MyPy where practical: `uv run mypy .`
+- Run all configured hooks with: `uv run pre-commit run --all-files`
 
 ## Testing
 
-- Run tests with: `pytest`
+- Run tests with: `uv run pytest`
+- Run a fast subset with: `uv run pytest -m "not slow and not gpu and not integration"`
 - Ensure all tests pass before submitting a PR.
 - Add tests for new features or bug fixes.
 
@@ -43,8 +53,9 @@ We welcome contributions to torchwm! This document outlines the guidelines for c
 
 1. Create a feature branch from `main`: `git checkout -b feature/your-feature`
 2. Make your changes and commit them.
-3. Push to your fork and create a PR.
-4. PRs must pass CI checks and have at least one approval.
+3. Run checks and tests: `uv run pre-commit run --all-files` and `uv run pytest`
+4. Push to your fork and create a PR.
+5. PRs must pass CI checks and have at least one approval.
 
 ## Code of Conduct
 

--- a/docs/source/configs_reference.md
+++ b/docs/source/configs_reference.md
@@ -23,6 +23,11 @@ class DreamerConfig:
     dmlab_config: Optional[dict] = None
     dmlab_renderer: str = "hardware"
 
+    # Procgen (optional)
+    procgen_distribution_mode: str = "easy"
+    procgen_num_levels: int = 0
+    procgen_start_level: Optional[int] = None
+
     # MuJoCo (optional)
     mujoco_xml_path: Optional[str] = None
     mujoco_xml_string: Optional[str] = None
@@ -35,6 +40,7 @@ class DreamerConfig:
     brax_backend: str = "generalized"
     brax_jit: bool = True
     brax_auto_reset: bool = False
+    brax_suppress_warp_warnings: bool = True
 
     # Unity ML-Agents
     unity_file_name: Optional[str] = None
@@ -67,9 +73,9 @@ class DreamerConfig:
     action_noise: float = 0.3
 
     # Learning
-    model_lr: float = 6e-4
-    actor_lr: float = 8e-5
-    value_lr: float = 8e-5
+    model_learning_rate: float = 6e-4
+    actor_learning_rate: float = 8e-5
+    value_learning_rate: float = 8e-5
     total_steps: int = int(5e6)
     seed_steps: int = 5000
     update_steps: int = 100
@@ -77,33 +83,36 @@ class DreamerConfig:
     batch_size: int = 50
     train_seq_len: int = 50
     imagine_horizon: int = 15
+    use_disc_model: bool = False
 
     # Loss
     free_nats: float = 3.0
-    kl_scale: float = 1.0
     discount: float = 0.99
     td_lambda: float = 0.95
     kl_loss_coeff: float = 1.0
     kl_alpha: float = 0.8
     disc_loss_coeff: float = 10.0
+    num_buckets: int = 255
+    symlog_range: float = 10.0
 
     # Optimization
     adam_epsilon: float = 1e-7
     grad_clip_norm: float = 100.0
 
-    # Exploration
-    expl_amount: float = 0.3
-    expl_decay: float = 0.0
-    expl_min: float = 0.0
-
-    # Logging
-    log_every: int = 1e4
-    log_scalars: bool = True
-    log_images: bool = True
-    log_videos: bool = False
-    save_every: int = 1e5
-    eval_every: int = 1e4
-    eval_episodes: int = 10
+    # Evaluation and checkpointing
+    test: bool = False
+    test_interval: int = 10000
+    test_episodes: int = 10
+    scalar_freq: int = int(1e3)
+    log_video_freq: int = -1
+    max_videos_to_save: int = 2
+    video_format: str = "gif"
+    video_fps: int = 20
+    checkpoint_interval: int = 10000
+    checkpoint_path: str = ""
+    restore: bool = False
+    experience_replay: str = ""
+    render: bool = False
 
     # WandB
     enable_wandb: bool = False
@@ -111,10 +120,15 @@ class DreamerConfig:
     wandb_project: str = "torchwm"
     wandb_entity: str = ""
     log_dir: str = "runs"
-
-    # Operator parameters
-    operator_image_size: int = 64
-    operator_action_dim: int = 6
+    data_dir: Optional[str] = None
+    log_level: str = "INFO"
+    log_file: Optional[str] = None
+    enable_tensorboard: bool = False
+    enable_console_metrics: bool = True
+    enable_jsonl: bool = True
+    jsonl_filename: str = "metrics.jsonl"
+    log_system_stats_freq: int = int(1e3)
+    detect_anomaly: bool = False
 ```
 
 ## JEPAConfig
@@ -161,43 +175,24 @@ class JEPAConfig:
 
     # Optimization
     ema: Tuple[float, float] = (0.996, 1.0)
-    clip_grad: float = 1.0
-    weight_decay: float = 0.0
-    epochs: int = 100
-    warmup_epochs: int = 40
-    start_epoch: int = 0
+    ipe_scale: float = 1.0
+    weight_decay: float = 0.04
+    final_weight_decay: float = 0.4
+    epochs: int = 300
+    warmup: int = 40
+    start_lr: float = 1e-6
     lr: float = 1.5e-4
-    min_lr: float = 1e-6
-    accum_iter: int = 1
-    output_dir: str = "./output"
-    log_dir: str = "./output"
-    device: str = "cuda"
-    seed: int = 0
-    resume: str = ""
-    auto_resume: bool = True
-    save_ckpt: bool = True
-    save_ckpt_freq: int = 20
-    save_ckpt_num: int = 3
-    start_ckpt: str = ""
-    debug: bool = False
-    num_debug: int = 10
-    wandb: bool = True
-    wandb_project: str = "jepa"
+    final_lr: float = 1e-6
+
+    # Logging
+    folder: str = "results/jepa"
+    write_tag: str = "jepa_run"
+    enable_wandb: bool = False
+    wandb_api_key: str = ""
+    wandb_project: str = "torchwm"
     wandb_entity: str = ""
     enable_sweep: bool = False
     sweep_config: Dict[str, Any] = {}
-    dist_eval: bool = True
-    no_env: bool = False
-    eval: bool = False
-    disable_rel_pos_bias: bool = True
-    disable_masking: bool = False
-    enable_deepspeed: bool = False
-    gradient_checkpointing: bool = True
-
-    # Operator parameters
-    operator_image_size: int = 224
-    operator_patch_size: int = 16
-    operator_mask_ratio: float = 0.75
 ```
 
 ## IRISConfig
@@ -250,7 +245,7 @@ class IRISConfig:
     adam_beta1: float = 0.9
     adam_beta2: float = 0.999
     weight_decay: float = 0.01
-    max_grad_norm: float = 10.0
+    grad_clip_norm: float = 10.0
     collect_epsilon: float = 0.1
     eval_temperature: float = 0.1
     start_autoencoder_after: int = 1
@@ -264,25 +259,12 @@ class IRISConfig:
     atari_100k: bool = True
     max_env_steps: int = 100000
     env_backend: str = "gym"
-    env_name: str = "ALE/Pong-v5"
+    env: str = "ALE/Pong-v5"
     action_repeat: int = 4
-    max_episode_steps: int = 108000
-    num_eval_episodes: int = 10
-    eval_max_episode_steps: int = 27000
-    buffer_capacity: int = 100000
-    num_workers: int = 4
-    prefetch_factor: int = 2
-
     # Logging
-    log_dir: str = "./logs"
-    checkpoint_dir: str = "./checkpoints"
-    use_wandb: bool = True
-    wandb_project: str = "iris"
-    wandb_entity: str = ""
-
-    # Operator parameters
-    operator_seq_length: int = 512
-    operator_vocab_size: int = 32000
+    log_interval: int = 1000
+    eval_episodes: int = 100
+    checkpoint_interval: int = 50
 ```
 
 ## DiamondConfig
@@ -297,6 +279,7 @@ class DiamondConfig:
 
     # Environment
     game: str = "Breakout-v5"
+    seed: int = 0
     obs_size: int = 64
     frameskip: int = 4
     max_noop: int = 30
@@ -352,8 +335,6 @@ class DiamondConfig:
     log_interval: int = 10
     eval_interval: int = 50
     save_interval: int = 100
-    num_seeds: int = 5
-    seed: int = 0
 
     # Operator parameters
     operator_state_dim: int = 32
@@ -409,7 +390,7 @@ cfg.unity_file_name = "env.exe"
 ```python :class: thebe
 # Basic training
 cfg.batch_size = 50
-cfg.learning_rate = 6e-4
+cfg.model_learning_rate = 6e-4
 cfg.total_steps = 5_000_000
 
 # Logging
@@ -417,7 +398,7 @@ cfg.enable_wandb = True
 cfg.wandb_project = "my_project"
 
 # Checkpointing
-cfg.save_every = 100_000
+cfg.checkpoint_interval = 100_000
 ```
 
 ### Advanced Configs
@@ -428,12 +409,11 @@ cfg.obs_embed_size = 2048
 cfg.num_units = 600
 cfg.deter_size = 300
 
-# Exploration
-cfg.expl_amount = 0.5
-cfg.expl_decay = 0.0001
+# Exploration noise (Dreamer)
+cfg.action_noise = 0.5
 
 # Loss weights
-cfg.kl_scale = 0.1
+cfg.kl_loss_coeff = 0.1
 cfg.free_nats = 1.0
 ```
 

--- a/docs/source/contributing.md
+++ b/docs/source/contributing.md
@@ -15,9 +15,15 @@ We welcome contributions to TorchWM! This guide covers how to get started.
    uv sync --dev
    ```
 
+   If you are not using `uv`, use the equivalent editable install:
+
+   ```bash
+   python -m pip install -e ".[dev]"
+   ```
+
 3. **Install pre-commit hooks**
    ```bash
-   pre-commit install
+   uv run pre-commit install
    ```
 
 ## Code Style
@@ -31,16 +37,16 @@ We use:
 Run checks:
 ```bash
 # Format code
-black .
+uv run black .
 
 # Lint
-ruff check .
+uv run ruff check .
 
 # Type check
-mypy .
+uv run mypy .
 
 # All checks
-pre-commit run --all-files
+uv run pre-commit run --all-files
 ```
 
 ## Testing
@@ -109,8 +115,8 @@ Add to `__init__.py` and create tests.
 3. **Make your changes**
 4. **Run tests and checks**
    ```bash
-   pre-commit run --all-files
-   pytest
+   uv run pre-commit run --all-files
+   uv run pytest
    ```
 5. **Update documentation** if needed
 6. **Commit your changes**

--- a/docs/source/dreamer.md
+++ b/docs/source/dreamer.md
@@ -139,7 +139,7 @@ cfg.env = "walker-walk"
 cfg.total_steps = 5_000_000
 
 # KL (single coefficient)
-cfg.kl_scale = 1.0
+cfg.kl_loss_coeff = 1.0
 
 agent = DreamerAgent(cfg)
 agent.train()
@@ -570,11 +570,11 @@ config.total_steps = 5_000_000
 config.batch_size = 50
 config.train_seq_len = 50
 config.imagine_horizon = 15
-config.model_lr = 6e-4
+config.model_learning_rate = 6e-4
 
 # Actor-critic
-config.actor_lr = 8e-5
-config.value_lr = 8e-5
+config.actor_learning_rate = 8e-5
+config.value_learning_rate = 8e-5
 config.discount = 0.99
 config.td_lambda = 0.95
 
@@ -583,12 +583,11 @@ config.kl_alpha = 0.8
 config.free_nats = 3.0
 
 # Exploration
-config.expl_amount = 0.3
-config.expl_decay = 0.0
+config.action_noise = 0.3
 
 # Logging
-config.log_every = 10_000
-config.save_every = 100_000
+config.scalar_freq = 10_000
+config.checkpoint_interval = 100_000
 config.enable_wandb = False
 ```
 
@@ -600,7 +599,7 @@ config.enable_wandb = False
 |-----------|------------|------------|--------|
 | `stoch_size` | 30 | 32 × 32 classes | Total stochastic capacity |
 | `deter_size` | 200 | 200 | GRU hidden size |
-| `model_lr` | 6e-4 | 3e-4 | World model learning rate |
+| `model_learning_rate` | 6e-4 | 3e-4 | World model learning rate |
 | `train_seq_len` | 50 | 50 | Sequence length per batch |
 | `batch_size` | 50 | 16 | Sequences per batch |
 | `free_nats` | 3.0 | 3.0 | KL free bits threshold |
@@ -609,12 +608,12 @@ config.enable_wandb = False
 
 | Parameter | V1 Default | V2 Default | Effect |
 |-----------|------------|------------|--------|
-| `actor_lr` | 8e-5 | 8e-5 | Policy learning rate |
-| `value_lr` | 8e-5 | 8e-5 | Critic learning rate |
+| `actor_learning_rate` | 8e-5 | 8e-5 | Policy learning rate |
+| `value_learning_rate` | 8e-5 | 8e-5 | Critic learning rate |
 | `imagine_horizon` | 15 | 15 | Imagination rollout length |
 | `discount` | 0.99 | 0.997 | Discount factor |
 | `td_lambda` | 0.95 | 0.95 | λ-return parameter |
-| `kl_scale` | 1.0 | 1.0 | KL loss coefficient |
+| `kl_loss_coeff` | 1.0 | 1.0 | KL loss coefficient |
 | `kl_alpha` | — | 0.8 | KL balancing weight (V2 only) |
 
 #### Environment Interaction
@@ -635,7 +634,7 @@ If the stochastic state is ignored by the dynamics, the model reduces to a
 deterministic RNN. Symptoms: good reconstruction but imagination diverges.
 
 **Fixes:**
-- Increase `kl_scale` (V1) or adjust `kl_alpha` (V2)
+- Increase `kl_loss_coeff` or adjust `kl_alpha` (V2)
 - Decrease `free_nats`
 - Reduce `stoch_size`
 
@@ -650,7 +649,7 @@ The prior predicts states that drift from realistic latents over long horizons.
 ### NaN loss during training
 
 **Fixes:**
-- Reduce `model_lr` to 1e-4
+- Reduce `model_learning_rate` to 1e-4
 - Tighten gradient clipping (default 100 → 10)
 - Enable layer norm
 
@@ -658,7 +657,7 @@ The prior predicts states that drift from realistic latents over long horizons.
 
 **Fixes:**
 - Increase `imagine_horizon` for delayed rewards
-- Increase entropy bonus via `expl_amount`
+- Increase exploration noise via `action_noise`
 - Verify critic loss is decreasing
 
 ## References

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -156,7 +156,8 @@ result = op(inputs)
 
 ### Integration with Configs
 
-Operators use parameters from config classes:
+Operators can reuse matching config fields, but operator-only parameters such as
+action dimensions should be supplied from the target environment:
 
 ```python :class: thebe
 import torchwm
@@ -164,8 +165,8 @@ import torchwm
 cfg = torchwm.create_config("dreamer")
 op = torchwm.get_operator(
     "dreamer",
-    image_size=cfg.operator_image_size,
-    action_dim=cfg.operator_action_dim,
+    image_size=cfg.image_size[0],
+    action_dim=6,
 )
 ```
 

--- a/docs/source/iris.md
+++ b/docs/source/iris.md
@@ -198,7 +198,7 @@ config.transformer_embed_dim = 256
 # Training
 config.total_epochs = 600
 config.env_steps_per_epoch = 200
-config.env_name = "ALE/Pong-v5"
+config.env = "ALE/Pong-v5"
 ```
 
 ### CLI
@@ -240,7 +240,7 @@ config.total_epochs = 600
 
 # Atari 100k
 config.atari_100k = True
-config.env_name = "ALE/Pong-v5"
+config.env = "ALE/Pong-v5"
 config.max_env_steps = 100000
 ```
 

--- a/docs/source/operators_guide.md
+++ b/docs/source/operators_guide.md
@@ -123,29 +123,32 @@ factories:
 ```python :class: thebe
 import torchwm
 
-# Dreamer
+# Dreamer: reuse matching environment/image fields and pass the action size
+# for your environment explicitly.
 dreamer_cfg = torchwm.create_config("dreamer")
 dreamer_op = torchwm.get_operator(
     "dreamer",
-    image_size=dreamer_cfg.operator_image_size,
-    action_dim=dreamer_cfg.operator_action_dim,
+    image_size=dreamer_cfg.image_size[0],
+    action_dim=6,
 )
 
-# JEPA
+# JEPA: reuse crop and patch sizes from JEPAConfig; mask_ratio is an
+# operator preprocessing choice, so pass it explicitly.
 jepa_cfg = torchwm.create_config("jepa")
 jepa_op = torchwm.get_operator(
     "jepa",
-    image_size=jepa_cfg.operator_image_size,
-    patch_size=jepa_cfg.operator_patch_size,
-    mask_ratio=jepa_cfg.operator_mask_ratio,
+    image_size=jepa_cfg.crop_size,
+    patch_size=jepa_cfg.patch_size,
+    mask_ratio=0.75,
 )
 
-# IRIS
+# IRIS: reuse vocabulary size from IRISConfig and choose the inference
+# sequence length required by your deployment.
 iris_cfg = torchwm.create_config("iris")
 iris_op = torchwm.get_operator(
     "iris",
-    seq_length=iris_cfg.operator_seq_length,
-    vocab_size=iris_cfg.operator_vocab_size,
+    seq_length=512,
+    vocab_size=iris_cfg.vocab_size,
 )
 ```
 

--- a/docs/source/training_guide.md
+++ b/docs/source/training_guide.md
@@ -84,7 +84,7 @@ import torchwm
 
 agent = torchwm.create_model(
     "iris",
-    env_name="Pong-v5",
+    env="ALE/Pong-v5",
     total_epochs=100,
     action_size=4,
     device=torch.device("cuda" if torch.cuda.is_available() else "cpu"),
@@ -118,7 +118,7 @@ for step in range(cfg.total_steps):
         metrics = agent.update(batch)
 
     # Log
-    if step % cfg.log_every == 0:
+    if step % cfg.scalar_freq == 0:
         print(f"Step {step}: {metrics}")
 ```
 
@@ -136,8 +136,23 @@ All training is controlled via config objects:
 
 ### Logging
 - `enable_wandb`: Weights & Biases logging
-- `log_dir`: TensorBoard log directory
+- `log_dir`: Base log directory for supported agents
+- `scalar_freq`/`log_interval`: Metric logging cadence, depending on the agent
 - `checkpoint_interval`: Save frequency
+
+### Starter YAML configs
+
+DIAMOND, IRIS, and JEPA include starter experiment YAML files in
+`world_models/configs/experiments/`. Use them with the unified CLI and optional
+OmegaConf/Hydra-style dot-list overrides:
+
+```bash
+torchwm train diamond --config world_models/configs/experiments/diamond.yaml preset=small seed=1
+torchwm train iris --config world_models/configs/experiments/iris.yaml total_epochs=100 env=ALE/Breakout-v5
+torchwm train jepa --config world_models/configs/experiments/jepa.yaml optimization.epochs=50 data.batch_size=128
+```
+
+Add `--print-config` to inspect the composed configuration without launching a run.
 
 ## Environment Setup
 

--- a/world_models/configs/experiments/diamond.yaml
+++ b/world_models/configs/experiments/diamond.yaml
@@ -15,4 +15,3 @@ environment_steps_per_epoch: 100
 epsilon_greedy: 0.01
 learning_rate: 0.0001
 device: cuda
-checkpoint_dir: checkpoints/diamond


### PR DESCRIPTION
### Motivation

- Keep documentation accurate by aligning the config reference and algorithm docs with the actual runtime config classes for Dreamer, JEPA, IRIS, and DIAMOND.
- Remove stale/incorrect field names and provide consistent examples so `--print-config` / OmegaConf composition and starter YAMLs are usable by users and CI.
- Harmonize contributor setup instructions (root `CONTRIBUTING.md` and Sphinx docs) around the project’s preferred developer tooling (`uv`) while preserving a pip fallback.

### Description

- Updated `docs/source/configs_reference.md` to match the real config classes: renamed Dreamer fields (`model_lr`→`model_learning_rate`, `actor_lr`→`actor_learning_rate`, `value_lr`→`value_learning_rate`, `kl_scale`→`kl_loss_coeff`, `expl_amount`→`action_noise`, etc.), added/removed fields to reflect `world_models/configs/*_config.py`, and added Dreamer options like `procgen_*`, `brax_suppress_warp_warnings`, `use_disc_model`, `num_buckets`, evaluation/checkpoint/logging fields and other logging plumbing.
- Brought JEPA/IRIS/Diamond docs into sync with code: JEPA optimization/logging names updated to match `world_models/configs/jepa_config.py`, IRIS changed `env_name`→`env` and `max_grad_norm`→`grad_clip_norm`, DIAMOND docs now reflect dataclass fields (added `seed` and removed an invalid `checkpoint_dir` starter key).
- Documented the built-in experiment starter YAMLs in the training guide and removed the invalid `checkpoint_dir` key from `world_models/configs/experiments/diamond.yaml` so YAML keys compose cleanly via `world_models.experiments` helpers.
- Harmonized contributor setup and developer commands: prefer `uv sync --dev` and `uv run <tool>` invocations in `CONTRIBUTING.md` and `docs/source/contributing.md`, while providing a pip/editable fallback and updating examples to use `scalar_freq`/`checkpoint_interval` and operator usage recommendations.

### Testing

- Ran a static validation script that parsed `docs/source/configs_reference.md` and compared documented fields to the actual config class attributes in `world_models/configs/*_config.py`; the check passed for Dreamer, JEPA, IRIS, and Diamond. (`python - <<'PY' ... PY` validation script). 
- Ran stale-field checks with `rg` (ripgrep) to find references to removed names; the scan confirmed references were updated. (`rg ...` checks). 
- Attempted to build the Sphinx HTML docs (`python -m sphinx -b html docs/source docs/build/html`) but the build could not run in this environment because Sphinx is not installed (automated check aborted). 
- Attempted to run `torchwm` training entrypoint `--print-config` for DIAMOND to exercise composition, but the run failed due to the environment missing `torch`; this prevented executing runtime composition checks that require heavy dependencies. (failure is environment-dependent, not a docs change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bf046e4088327b30ced31f07059bf)