### PR TITLE
Fix uv all-extras dependency resolution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ gym = [
     "autorom>=0.6.1",
 ]
 ml-agents = [
-    "mlagents-envs>=0.29.0",
+    "mlagents-envs>=0.28.0,<0.29.0",
 ]
 mujoco = [
     "mujoco>=3.2.0",
@@ -80,8 +80,8 @@ viz = [
     "uvicorn>=0.35.0",
     "myst-parser>=2.0.0,<5.0.0",
     "nbsphinx>=0.9.8",
-    "python-multipart>=0.0.27",
-    "starlette>=1.0.1",
+    "python-multipart>=0.0.22",
+    "starlette>=0.52.1",
 ]
 ml = [
     "tensorboard>=2.20.0",
@@ -94,7 +94,7 @@ dev = [
     "pytest-timeout>=2.3.1",
     "pre-commit>=4.5.0",
     "mypy>=1.19.1",
-    "gitpython>=3.1.49",
+    "gitpython>=3.1.46",
 ]
 all = [
     "torchwm[gym,viz,ml,ml-agents,mujoco,robotics,brax,procgen,bsuite,dev,docs]",
@@ -111,7 +111,7 @@ docs = [
     "sphinxext-opengraph>=0.13.0",
     "myst-parser>=2.0.0,<5.0.0",
     "nbsphinx>=0.9.8",
-    "mistune>=3.2.1",
+    "mistune>=3.2.0",
     "nbconvert>=7.17.1",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -911,7 +911,7 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.49"
+version = "3.1.46"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
@@ -1312,7 +1312,7 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.15"
+version = "3.11"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
@@ -1748,7 +1748,7 @@ wheels = [
 
 [[package]]
 name = "mistune"
-version = "3.2.1"
+version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9d/55/d01f0c4b45ade6536c51170b9043db8b2ec6ddf4a35c7ea3f5f559ac935b/mistune-3.2.0.tar.gz", hash = "sha256:708487c8a8cdd99c9d90eb3ed4c3ed961246ff78ac82f03418f5183ab70e398a", size = 95467, upload-time = "2025-12-23T11:36:34.994Z" }
 wheels = [
@@ -2469,7 +2469,7 @@ wheels = [
 
 [[package]]
 name = "pillow"
-version = "12.2.0"
+version = "11.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/d0d6dea55cd152ce3d6767bb38a8fc10e33796ba4ba210cbab9354b6d238/pillow-11.3.0.tar.gz", hash = "sha256:3828ee7586cd0b2091b6209e5ad53e20d0649bbe87164a459d0676e035e8f523", size = 47113069, upload-time = "2025-07-01T09:16:30.666Z" }
 wheels = [
@@ -3001,7 +3001,7 @@ wheels = [
 
 [[package]]
 name = "python-dotenv"
-version = "1.2.2"
+version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
 wheels = [
@@ -3010,7 +3010,7 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.27"
+version = "0.0.22"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
 wheels = [
@@ -3884,7 +3884,7 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.1"
+version = "0.52.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -4287,7 +4287,7 @@ requires-dist = [
     { name = "huggingface-hub", specifier = ">=1.14.0" },
     { name = "huggingface-hub", marker = "extra == 'gym'", specifier = ">=0.23.0" },
     { name = "jax", marker = "extra == 'brax'", specifier = ">=0.10.1" },
-    { name = "mlagents-envs", marker = "extra == 'ml-agents'", specifier = ">=0.28.0" },
+    { name = "mlagents-envs", marker = "extra == 'ml-agents'", specifier = ">=0.28.0,<0.29.0" },
     { name = "moviepy", specifier = ">=2.2.1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.19.1" },
     { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=2.0.0,<5.0.0" },
@@ -4493,7 +4493,7 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.7.0"
+version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [


### PR DESCRIPTION
### Motivation
- Avoid an unsatisfiable install when requesting `torchwm[all]` caused by `mlagents-envs` pulling incompatible NumPy ranges. 
- Ensure optional extras do not force versions that conflict with the lockfile artifacts or the project NumPy requirement. 
- Allow `uv` to parse and use the existing lockfile by fixing mismatched package version headers that prevented lock parsing.

### Description
- Constrain the `ml-agents` extra in `pyproject.toml` to `mlagents-envs>=0.28.0,<0.29.0` to keep it compatible with the project `numpy>=1.26.0` requirement. 
- Lowered several optional dependency minima in `pyproject.toml`: `python-multipart` -> `>=0.0.22`, `starlette` -> `>=0.52.1`, `gitpython` -> `>=3.1.46`, and `mistune` -> `>=3.2.0` so they match the versions represented in the lockfile. 
- Updated `uv.lock` package `version` headers and related metadata to match artifact filenames (notably `gitpython`, `idna`, `mistune`, `pillow`, `python-dotenv`, `python-multipart`, `starlette`, `urllib3`) and updated the `ml-agents` metadata specifier to `>=0.28.0,<0.29.0` so the lockfile parses cleanly and is consistent with the declared constraints. 

### Testing
- Ran a TOML/lockfile validation script (`python - <<'PY' ... PY`) that verified `pyproject.toml` and `uv.lock` parse and that lockfile package versions match artifact filenames (passed). 
- Ran `git diff --check` to confirm no whitespace/conflict markers (passed). 
- Attempted `uv sync --all-extras --locked --dry-run` and `uv sync --all-extras --locked --dry-run --no-build-isolation`; both progressed past lock parsing but ultimately failed in this environment due to network/tunnel errors and a missing local `setuptools` respectively (environmental failures, not changeset regressions).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33cba2896c8327ab9154d6e8efb867)